### PR TITLE
Tool Dependency Test

### DIFF
--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -23,12 +23,7 @@ logger = logging.getLogger("mcp-panther")
 async def execute_data_lake_query(
     sql: str, database_name: Optional[str] = "panther_logs.public"
 ) -> Dict[str, Any]:
-    """Execute a Snowflake SQL query against Panther's data lake. RECOMMENDED: First query the information_schema.columns table for the PUBLIC table schema and the p_log_type to get the correct column names and types to query.
-
-    Args:
-        sql: The Snowflake SQL query to execute (tables are named after p_log_type)
-        database_name: Optional database name to execute against ("panther_logs.public": all logs, "panther_rule_matches.public": rule matches)
-    """
+    """Execute a performant Snowflake SQL query against Panther's data lake. REQUIRED: USE THE get_table_columns TOOL FIRST to get the correct table schema. THE QUERY MUST ALSO INCLUDE A FILTER ON p_event_time WITH A MAX TIME DURATION OF 90 DAYS."""
     logger.info("Executing data lake query")
 
     try:


### PR DESCRIPTION
### Description

MCP tools behave similarly to Agent tools in that you can describe explicit dependencies in their descriptions. This change updates the `execute_data_lake` func signature/tool description to require that the MCP client call one of the tools to understand the schema prior to execution. 

It ALSO describes a (soft) requirement for adding a filter on the `p_event_time` indexed field. Once we have unit tests in place, we could strictly enforce using `re` or a Python library like `sqlalchemy`.

An additional question is, which other tools could we apply this to? And should we take a natural language approach to tool descriptions versus the [Google function docstring style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)?

### References

Optional link to tickets or issues.

### Checklist

- [x] Added unit tests (not yet)
- [x] Tested end to end, including screenshots or videos (below)

<img width="897" alt="Screenshot 2025-04-09 at 2 20 29 PM" src="https://github.com/user-attachments/assets/eb514b6e-4289-4099-bbd1-1405e1afc881" />

<img width="892" alt="Screenshot 2025-04-09 at 2 20 16 PM" src="https://github.com/user-attachments/assets/40a58c80-607c-47b7-afdf-454872963819" />

### Notes for Reviewing

Testing steps to help reviewers test code. Include any Feature Flags or Pulumi Configs needed to test.
