### PR TITLE
datalake tools: update to always require a database name when looking up tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,19 @@ lint:
 build-docker:
 	docker build -t mcp-panther .
 
+# Create a virtual environment using uv (https://github.com/astral-sh/uv)
+# After creating, run: source .venv/bin/activate
 venv:
 	uv venv
 
-dev: venv
-	. .venv/bin/activate
+# Install development dependencies (run after activating virtual environment)
+dev-deps:
+	uv pip install -e ".[dev]"
 
+# Run tests (requires dev dependencies to be installed first)
+test:
+	pytest
+
+# Synchronize dependencies with pyproject.toml
 sync:
 	uv sync

--- a/README.md
+++ b/README.md
@@ -216,9 +216,8 @@ The server provides tools organized by common SIEM workflows:
 | | `get_data_lake_query_results` | Get results from a previously executed data lake query | "Get results for query ID abc123" |
 | | `list_log_sources` | List log sources with optional filters (health status, log types, integration type) | "Show me all healthy S3 log sources" |
 | | `get_table_schema` | Get schema information for a specific table | "Show me the schema for the AWS_CLOUDTRAIL table" |
-| | `get_data_lake_dbs_tables_columns` | List databases, tables, and columns in the data lake | "List all available tables in the panther_logs database" |
 | | `list_databases` | List all available data lake databases in Panther | "List all available databases" |
-| | `list_tables` | List all available tables in Panther's data lake | "List all available tables" |
+| | `list_tables_for_database` | List all available tables for a specific database in Panther's data lake | "What tables are in the panther_logs database" |
 | | `get_tables_for_database` | Get all tables for a specific data lake database | "What tables are within the panther_logs.public database" |
 | | `get_table_columns` | Get column details for a specific data lake table | "What columns exist within the table panther_logs.public.aws_cloudtrail" |
 | **Global Helpers** | | | |

--- a/src/mcp_panther/panther_mcp_core/queries.py
+++ b/src/mcp_panther/panther_mcp_core/queries.py
@@ -194,24 +194,6 @@ query GetDataLakeQuery($id: ID!, $root: Boolean = false) {
 }
 """)
 
-ALL_DATABASE_ENTITIES_QUERY = gql("""
-query AllDatabaseEntities {
-  dataLakeDatabases {
-    name
-    description
-    tables {
-      name
-      description
-      columns {
-        name
-        description
-        type
-      }
-    }
-  }
-}
-""")
-
 LIST_DATABASES_QUERY = gql("""
 query ListDatabases {
     dataLakeDatabases {

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ cli = [
 
 [[package]]
 name = "mcp-panther"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Description

After doing some internal testing we noticed that it is not reliable to try and get all database names and tables .. as the response size can be too much for the model to handle. 

This updates logic so each call to list tables will require a database name .. which the list_databases tool will provide.

### Changes
- Removes problematic tool
- Updates list tables to require a parameter for database name
- Minor additions to Makefile
- Readme updates to reflect tool name changes


### Checklist

- [ ] Added unit tests
- [x] Tested end to end, including screenshots or videos

### Notes for Reviewing

Testing steps to help reviewers test code.
