### PR TITLE
adds signal handlers and support for sse transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "mcp[cli]>=1.6.0",
     "pip-system-certs>=0.1.0",
     "python-dotenv>=1.1.0",
+    "click>=8.1.0",
+    "uvicorn>=0.24.0",
+    "starlette>=0.35.0",
 ]
 
 [project.optional-dependencies]
@@ -22,7 +25,7 @@ dev = [
 ]
 
 [project.scripts]
-mcp-panther = "mcp_panther:main"
+mcp-panther = "mcp_panther.server:main"
 
 [tool.ruff]
 # Allow autofix behavior for specified rules

--- a/src/mcp_panther/__init__.py
+++ b/src/mcp_panther/__init__.py
@@ -1,13 +1,3 @@
-"""
-MCP Panther - An MCP server for interacting with Panther Security Platform.
-"""
+from .server import main
 
-from .server import MCP_SERVER_NAME, mcp
-
-
-def main():
-    """Entry point for the MCP server that delegates to MCP's run method."""
-    mcp.run()
-
-
-__all__ = ["mcp", "main", "MCP_SERVER_NAME"]
+__all__ = ["main"]

--- a/src/mcp_panther/__main__.py
+++ b/src/mcp_panther/__main__.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+from .server import main
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\nGracefully exiting due to keyboard interrupt...", file=sys.stderr)
+        os._exit(0)  # Force immediate exit

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -1,8 +1,15 @@
+import asyncio
 import logging
+import os
+import signal
 import sys
 
+import click
+import uvicorn
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.routing import Mount
 
 # Load environment variables from .env file if it exists
 load_dotenv()
@@ -10,11 +17,17 @@ load_dotenv()
 # Server name
 MCP_SERVER_NAME = "mcp-panther"
 
+# Get log level from environment variable, default to DEBUG if not set
+log_level_name = os.environ.get("LOG_LEVEL", "DEBUG")
+
+# Convert string log level to logging constant
+log_level = getattr(logging, log_level_name.upper(), logging.DEBUG)
+
 # Configure logging with more detail
 logging.basicConfig(
-    level=logging.DEBUG,  # Change to DEBUG for more info
+    level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    stream=sys.stderr,  # Ensure logs go to stderr
+    stream=sys.stderr,
 )
 logger = logging.getLogger(MCP_SERVER_NAME)
 
@@ -23,16 +36,13 @@ logger = logging.getLogger(MCP_SERVER_NAME)
 # 2. When running with MCP inspector: `uv run mcp dev src/mcp_panther/server.py`
 # 3. When installing: `uv run mcp install src/mcp_panther/server.py`
 try:
-    # Import MCP registries
     from panther_mcp_core.prompts.registry import register_all_prompts
     from panther_mcp_core.resources.registry import register_all_resources
     from panther_mcp_core.tools.registry import register_all_tools
 except ImportError:
-    # Import MCP registries
     from .panther_mcp_core.prompts.registry import register_all_prompts
     from .panther_mcp_core.resources.registry import register_all_resources
     from .panther_mcp_core.tools.registry import register_all_tools
-
 
 # Server dependencies
 deps = [
@@ -47,9 +57,67 @@ mcp = FastMCP(MCP_SERVER_NAME, dependencies=deps)
 
 # Register all tools with MCP using the registry
 register_all_tools(mcp)
-
 # Register all prompts with MCP using the registry
 register_all_prompts(mcp)
-
 # Register all resources with MCP using the registry
 register_all_resources(mcp)
+
+
+def handle_signals():
+    def signal_handler(sig, frame):
+        logger.info(f"Received signal {sig}, shutting down...")
+        os._exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGHUP, signal_handler)
+
+
+@click.command()
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse"]),
+    default="stdio",
+    help="Transport type (stdio or sse)",
+)
+@click.option("--port", default=3000, help="Port to use for SSE transport")
+@click.option("--host", default="127.0.0.1", help="Host to bind to for SSE transport")
+def main(transport: str, port: int, host: str):
+    """Run the Panther MCP server with the specified transport"""
+    # Set up signal handling
+    handle_signals()
+
+    # Environment variable can override the transport
+    env_transport = os.environ.get("MCP_TRANSPORT")
+    if env_transport in ["stdio", "sse"]:
+        transport = env_transport
+
+    host = os.environ.get("MCP_HOST", default=host)
+    port = os.environ.get("MCP_PORT", default=port)
+
+    if transport == "sse":
+        # Create the Starlette app
+        app = Starlette(
+            debug=True,
+            routes=[
+                Mount("/", app=mcp.sse_app()),
+            ],
+        )
+
+        logger.info(f"Starting Panther MCP Server with SSE transport on {host}:{port}")
+        # Use Uvicorn's Config and Server classes for more control
+        config = uvicorn.Config(app, host=host, port=port, timeout_graceful_shutdown=1)
+        server = uvicorn.Server(config)
+
+        # Override the default behavior
+        server.force_exit = True  # This makes Ctrl+C force exit
+
+        try:
+            asyncio.run(server.serve())
+        except KeyboardInterrupt:
+            logger.info("Keyboard interrupt received, forcing immediate exit")
+            os._exit(0)
+    else:
+        logger.info("Starting Panther MCP Server with stdio transport")
+        # Let FastMCP handle all the asyncio details internally
+        mcp.run()

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -77,23 +77,23 @@ def handle_signals():
 @click.option(
     "--transport",
     type=click.Choice(["stdio", "sse"]),
-    default="stdio",
+    default=os.environ.get("MCP_TRANSPORT", default="stdio"),
     help="Transport type (stdio or sse)",
 )
-@click.option("--port", default=3000, help="Port to use for SSE transport")
-@click.option("--host", default="127.0.0.1", help="Host to bind to for SSE transport")
+@click.option(
+    "--port",
+    default=int(os.environ.get("MCP_PORT", default="3000")),
+    help="Port to use for SSE transport",
+)
+@click.option(
+    "--host",
+    default=os.environ.get("MCP_HOST", default="127.0.0.1"),
+    help="Host to bind to for SSE transport",
+)
 def main(transport: str, port: int, host: str):
     """Run the Panther MCP server with the specified transport"""
     # Set up signal handling
     handle_signals()
-
-    # Environment variable can override the transport
-    env_transport = os.environ.get("MCP_TRANSPORT")
-    if env_transport in ["stdio", "sse"]:
-        transport = env_transport
-
-    host = os.environ.get("MCP_HOST", default=host)
-    port = os.environ.get("MCP_PORT", default=port)
 
     if transport == "sse":
         # Create the Starlette app

--- a/uv.lock
+++ b/uv.lock
@@ -352,10 +352,13 @@ version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "click" },
     { name = "gql" },
     { name = "mcp", extra = ["cli"] },
     { name = "pip-system-certs" },
     { name = "python-dotenv" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -370,6 +373,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.14" },
+    { name = "click", specifier = ">=8.1.0" },
     { name = "gql", specifier = ">=3.5.2" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "pip-system-certs", specifier = ">=0.1.0" },
@@ -379,6 +383,8 @@ requires-dist = [
     { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.2" },
+    { name = "starlette", specifier = ">=0.35.0" },
+    { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
### Description
We weren't properly handling signals before this change. This also allows us to run utilizing the sse transport mode (if specified, we still default to stdio).

### References

Optional link to tickets or issues.

### Checklist

- [ ] Added unit tests
- [x] Tested end to end, including screenshots or videos
  - Ran some manual tests using docker in sse mode, and running on local machine
     - note: best way to test this out locally is to 
     - setup virtual env
     - run `make dev-deps`
     - Run in stdio mode
        -  `uv run mcp-panther`
   - run in sse mode
      - `uv run mcp-panther --transport sse --host 0.0.0.0`
  - test in docker
     - `make build-docker`
     - `docker run -i -e PANTHER_INSTANCE_URL=YOUR_HOST -e PANTHER_API_KEY=YOUR_KEY -e MCP_HOST=0.0.0.0 -e MCP_TRANSPORT=sse -e -p 3001:3000 --rm mcp-panther`
        - you should be able to visit `http://localhost:30001/sse` in your browser

### Notes for Reviewing

Testing steps to help reviewers test code.
