### PR TITLE
Add tool for fetching recent events on an alert.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# OS generated files
+.DS_Store
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The server provides tools organized by common SIEM workflows:
 | **Alert Management** | | | |
 | | `list_alerts` | List alerts with comprehensive filtering options (date range, severity, status, etc.) | "Show me all high severity alerts from the last 24 hours" |
 | | `get_alert_by_id` | Get detailed information about a specific alert | "What's the status of alert 8def456?" |
-| | `get_alert_events` | Get the most recent events for a given alert | "Show me events associated with alert 8def456" |
+| | `get_alert_events` | Get a small sampling of events for a given alert | "Show me events associated with alert 8def456" |
 | | `update_alert_status` | Update the status of one or more alerts | "Mark alerts abc123 and def456 as resolved" |
 | | `add_alert_comment` | Add a comment to a Panther alert | "Add comment 'Looks pretty bad' to alert abc123" |
 | | `update_alert_assignee_by_id` | Update the assignee of one or more alerts | "Assign alerts abc123 and def456 to John" |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The server provides tools organized by common SIEM workflows:
 | **Alert Management** | | | |
 | | `list_alerts` | List alerts with comprehensive filtering options (date range, severity, status, etc.) | "Show me all high severity alerts from the last 24 hours" |
 | | `get_alert_by_id` | Get detailed information about a specific alert | "What's the status of alert 8def456?" |
+| | `get_alert_events` | Get the most recent events for a given alert | "Show me events associated with alert 8def456" |
 | | `update_alert_status` | Update the status of one or more alerts | "Mark alerts abc123 and def456 as resolved" |
 | | `add_alert_comment` | Add a comment to a Panther alert | "Add comment 'Looks pretty bad' to alert abc123" |
 | | `update_alert_assignee_by_id` | Update the assignee of one or more alerts | "Assign alerts abc123 and def456 to John" |

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -5,7 +5,12 @@ Tools for interacting with Panther alerts.
 import logging
 from typing import Any, Dict, List
 
-from ..client import _create_panther_client, _execute_query, _get_today_date_range, get_rest_client
+from ..client import (
+    _create_panther_client,
+    _execute_query,
+    _get_today_date_range,
+    get_rest_client,
+)
 from ..queries import (
     ADD_ALERT_COMMENT_MUTATION,
     GET_ALERT_BY_ID_QUERY,
@@ -432,7 +437,9 @@ async def get_alert_events(alert_id: str, limit: int = 10) -> Dict[str, Any]:
         if limit < 1:
             raise ValueError("limit must be greater than 0")
         if limit > max_limit:
-            logger.warning(f"limit {limit} exceeds maximum of {max_limit}, using {max_limit} instead")
+            logger.warning(
+                f"limit {limit} exceeds maximum of {max_limit}, using {max_limit} instead"
+            )
             limit = max_limit
 
         params = {"limit": limit}
@@ -451,13 +458,11 @@ async def get_alert_events(alert_id: str, limit: int = 10) -> Dict[str, Any]:
 
         events = result.get("results", [])
 
-        logger.info(f"Successfully retrieved {len(events)} events for alert ID: {alert_id}")
+        logger.info(
+            f"Successfully retrieved {len(events)} events for alert ID: {alert_id}"
+        )
 
-        return {
-            "success": True,
-            "events": events,
-            "total_events": len(events)
-        }
+        return {"success": True, "events": events, "total_events": len(events)}
     except Exception as e:
         logger.error(f"Failed to fetch alert events: {str(e)}")
         return {"success": False, "message": f"Failed to fetch alert events: {str(e)}"}

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -5,7 +5,7 @@ Tools for interacting with Panther alerts.
 import logging
 from typing import Any, Dict, List
 
-from ..client import _create_panther_client, _execute_query, _get_today_date_range
+from ..client import _create_panther_client, _execute_query, _get_today_date_range, get_rest_client
 from ..queries import (
     ADD_ALERT_COMMENT_MUTATION,
     GET_ALERT_BY_ID_QUERY,
@@ -405,3 +405,57 @@ async def update_alert_assignee_by_id(
             "success": False,
             "message": f"Failed to update alert assignee: {str(e)}",
         }
+
+
+@mcp_tool
+async def get_alert_events(alert_id: str, limit: int = 10) -> Dict[str, Any]:
+    """
+    Get the most recent events for a specific Panther alert by ID.
+
+    This tool does not support pagination to prevent long-running, expensive queries.
+
+    Args:
+        alert_id: The ID of the alert to get events for
+        limit: Maximum number of events to return (default: 10, maximum: 50)
+
+    Returns:
+        Dict containing:
+        - success: Boolean indicating if the request was successful
+        - events: List of most recent events if successful
+        - message: Error message if unsuccessful
+    """
+    logger.info(f"Fetching events for alert ID: {alert_id}")
+
+    try:
+        if limit < 1:
+            raise ValueError("limit must be greater than 0")
+        if limit > 50:
+            logger.warning(f"limit {limit} exceeds maximum of 50, using 50 instead")
+            limit = 50
+
+        params = {"limit": limit}
+
+        async with get_rest_client() as client:
+            result, status = await client.get(
+                f"/alerts/{alert_id}/events", params=params, expected_codes=[200, 404]
+            )
+
+            if status == 404:
+                logger.warning(f"No alert found with ID: {alert_id}")
+                return {
+                    "success": False,
+                    "message": f"No alert found with ID: {alert_id}",
+                }
+
+        events = result.get("results", [])
+
+        logger.info(f"Successfully retrieved {len(events)} events for alert ID: {alert_id}")
+
+        return {
+            "success": True,
+            "events": events,
+            "total_events": len(events)
+        }
+    except Exception as e:
+        logger.error(f"Failed to fetch alert events: {str(e)}")
+        return {"success": False, "message": f"Failed to fetch alert events: {str(e)}"}

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -410,13 +410,14 @@ async def update_alert_assignee_by_id(
 @mcp_tool
 async def get_alert_events(alert_id: str, limit: int = 10) -> Dict[str, Any]:
     """
-    Get the most recent events for a specific Panther alert by ID.
+    Get events for a specific Panther alert by ID.
+    We make a best effort to return the first events for an alert, but order is not guaranteed.
 
     This tool does not support pagination to prevent long-running, expensive queries.
 
     Args:
         alert_id: The ID of the alert to get events for
-        limit: Maximum number of events to return (default: 10, maximum: 50)
+        limit: Maximum number of events to return (default: 10, maximum: 10)
 
     Returns:
         Dict containing:
@@ -425,13 +426,14 @@ async def get_alert_events(alert_id: str, limit: int = 10) -> Dict[str, Any]:
         - message: Error message if unsuccessful
     """
     logger.info(f"Fetching events for alert ID: {alert_id}")
+    max_limit = 10
 
     try:
         if limit < 1:
             raise ValueError("limit must be greater than 0")
-        if limit > 50:
-            logger.warning(f"limit {limit} exceeds maximum of 50, using 50 instead")
-            limit = 50
+        if limit > max_limit:
+            logger.warning(f"limit {limit} exceeds maximum of {max_limit}, using {max_limit} instead")
+            limit = max_limit
 
         params = {"limit": limit}
 

--- a/tests/panther_mcp_core/tools/test_alerts.py
+++ b/tests/panther_mcp_core/tools/test_alerts.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.utils.helpers import patch_graphql_client, patch_execute_query
+from tests.utils.helpers import patch_graphql_client, patch_execute_query, patch_rest_client
 
 from mcp_panther.panther_mcp_core.tools.alerts import (
     list_alerts,
@@ -8,6 +8,7 @@ from mcp_panther.panther_mcp_core.tools.alerts import (
     update_alert_status,
     add_alert_comment,
     update_alert_assignee_by_id,
+    get_alert_events,
 )
 
 MOCK_ALERT = {
@@ -357,3 +358,76 @@ async def test_update_alert_assignee_with_empty_result(mock_execute_query):
 
     assert result["success"] is False
     assert "Failed to update alert assignee" in result["message"]
+
+@pytest.mark.asyncio
+@patch_rest_client(ALERTS_MODULE_PATH)
+async def test_get_alert_events_success(mock_rest_client):
+    """Test successful retrieval of alert events."""
+    mock_events = [
+        {"p_row_id": "event-1", "p_event_time": "2025-04-23 17:07:00.218308897", "p_alert_id": "c89fe49d40e58e82d30755f59d401a93"},
+        {"p_row_id": "event-2", "p_event_time": "2025-04-23 17:08:00.218308897", "p_alert_id": "c89fe49d40e58e82d30755f59d401a93"}
+    ]
+    mock_response = {"results": mock_events}
+    
+    mock_rest_client.get.return_value = (mock_response, 200)
+    
+    result = await get_alert_events(MOCK_ALERT["id"])
+    
+    assert result["success"] is True
+    assert len(result["events"]) == 2
+    assert result["total_events"] == 2
+    assert result["events"][0]["id"] == "event-1"
+    assert result["events"][1]["id"] == "event-2"
+    
+    mock_rest_client.get.assert_called_once()
+    args, kwargs = mock_rest_client.get.call_args
+    assert args[0] == f"/alerts/{MOCK_ALERT['id']}/events"
+    assert kwargs["params"] == {"limit": 10}
+
+@pytest.mark.asyncio
+@patch_rest_client(ALERTS_MODULE_PATH)
+async def test_get_alert_events_not_found(mock_rest_client):
+    """Test handling of non-existent alert when getting events."""
+    mock_rest_client.get.return_value = ({}, 404)
+    
+    result = await get_alert_events("nonexistent-alert")
+    
+    assert result["success"] is False
+    assert "No alert found with ID" in result["message"]
+
+@pytest.mark.asyncio
+@patch_rest_client(ALERTS_MODULE_PATH)
+async def test_get_alert_events_error(mock_rest_client):
+    """Test handling of errors when getting alert events."""
+    mock_rest_client.get.side_effect = Exception("Test error")
+    
+    result = await get_alert_events(MOCK_ALERT["id"])
+    
+    assert result["success"] is False
+    assert "Failed to fetch alert events" in result["message"]
+
+@pytest.mark.asyncio
+async def test_get_alert_events_invalid_limit():
+    """Test handling of invalid limit value."""
+    result = await get_alert_events(MOCK_ALERT["id"], limit=0)
+    
+    assert result["success"] is False
+    assert "limit must be greater than 0" in result["message"]
+
+@pytest.mark.asyncio
+@patch_rest_client(ALERTS_MODULE_PATH)
+async def test_get_alert_events_limit_exceeds_max(mock_rest_client):
+    """Test that limit is capped at 50 when a larger value is provided."""
+    mock_events = [{"p_row_id": f"event-{i}"} for i in range(1, 50)]
+    mock_response = {"results": mock_events}
+    
+    mock_rest_client.get.return_value = (mock_response, 200)
+    
+    result = await get_alert_events(MOCK_ALERT["id"], limit=100)
+    
+    assert result["success"] is True
+    
+    mock_rest_client.get.assert_called_once()
+    args, kwargs = mock_rest_client.get.call_args
+    assert args[0] == f"/alerts/{MOCK_ALERT['id']}/events"
+    assert kwargs["params"]["limit"] == 50

--- a/tests/panther_mcp_core/tools/test_alerts.py
+++ b/tests/panther_mcp_core/tools/test_alerts.py
@@ -376,8 +376,8 @@ async def test_get_alert_events_success(mock_rest_client):
     assert result["success"] is True
     assert len(result["events"]) == 2
     assert result["total_events"] == 2
-    assert result["events"][0]["id"] == "event-1"
-    assert result["events"][1]["id"] == "event-2"
+    assert result["events"][0]["p_row_id"] == "event-1"
+    assert result["events"][1]["p_row_id"] == "event-2"
     
     mock_rest_client.get.assert_called_once()
     args, kwargs = mock_rest_client.get.call_args
@@ -417,8 +417,8 @@ async def test_get_alert_events_invalid_limit():
 @pytest.mark.asyncio
 @patch_rest_client(ALERTS_MODULE_PATH)
 async def test_get_alert_events_limit_exceeds_max(mock_rest_client):
-    """Test that limit is capped at 50 when a larger value is provided."""
-    mock_events = [{"p_row_id": f"event-{i}"} for i in range(1, 50)]
+    """Test that limit is capped at 10 when a larger value is provided."""
+    mock_events = [{"p_row_id": f"event-{i}"} for i in range(1, 10)]
     mock_response = {"results": mock_events}
     
     mock_rest_client.get.return_value = (mock_response, 200)
@@ -430,4 +430,4 @@ async def test_get_alert_events_limit_exceeds_max(mock_rest_client):
     mock_rest_client.get.assert_called_once()
     args, kwargs = mock_rest_client.get.call_args
     assert args[0] == f"/alerts/{MOCK_ALERT['id']}/events"
-    assert kwargs["params"]["limit"] == 50
+    assert kwargs["params"]["limit"] == 10


### PR DESCRIPTION
### Description

Adds the ability to fetch up to 10 events for a given alert.
Does not support pagination by design to prevent excessive datalake querying.

### References

Optional link to tickets or issues.

### Checklist

- [x] Added unit tests
- [x] Tested end to end, including screenshots or videos

### Notes for Reviewing

Testing steps to help reviewers test code.
