### PR TITLE
Remove dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# Panther API key for authentication
-# You can get this from your Panther dashboard
-PANTHER_API_KEY=your_panther_api_key_here
-
-# Any valid link to your panther instance UI
-PANTHER_INSTANCE_URL=https://YOUR-INSTANCE-INSTANCE.domain

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dev-deps:
 
 # Run tests (requires dev dependencies to be installed first)
 test:
-	pytest
+	uv run pytest
 
 # Synchronize dependencies with pyproject.toml
 sync:

--- a/README.md
+++ b/README.md
@@ -88,15 +88,13 @@ Use the command, args, and env variables below:
         "gql[aiohttp]",
         "--with",
         "mcp[cli]",
-        "--with",
-        "python-dotenv",
         "mcp",
         "run",
-        "PATH/TO/MCPS/mcp-panther/src/mcp_panther/server.py"
+        "PATH-TO-LOCAL-MCP-SERVERS/mcp-panther/src/mcp_panther/server.py"
       ],
       "env": {
         "PANTHER_INSTANCE_URL": "https://YOUR-PANTHER-INSTANCE.domain",
-        "PANTHER_API_KEY": "YOUR-API-KEY"
+        "PANTHER_API_KEY": "YOUR-PANTHER-API-TOKEN"
       }
     }
   }
@@ -134,16 +132,7 @@ You will need to run `make build-docker` to build the image
 
 ### Credentials
 
-Your Panther API key and URL can be configured in two ways:
-
-1. Through the MCP Client configuration's `env` key (as shown in the Configuration section above). This will take the highest precedence.
-
-2. Using a `.env` file in the root repository directory with the following format:
-
-```
-PANTHER_INSTANCE_URL=https://YOUR-PANTHER-INSTANCE.domain
-PANTHER_API_KEY=YOUR-API-KEY
-```
+Your Panther API key and URL should be configured through the MCP Client configuration's `env` key (as shown in the Configuration section above).
 
 Make sure to replace the placeholder values with your actual Panther instance URLs and API key.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Use the command, args, and env variables below:
       ],
       "env": {
         "PANTHER_INSTANCE_URL": "https://YOUR-PANTHER-INSTANCE.domain",
-        "PANTHER_API_KEY": "YOUR-PANTHER-API-TOKEN"
+        "PANTHER_API_TOKEN": "YOUR-PANTHER-API-TOKEN"
       }
     }
   }
@@ -115,13 +115,13 @@ You will need to run `make build-docker` to build the image
         "run",
         "-i",
         "-e", "PANTHER_INSTANCE_URL",
-        "-e", "PANTHER_API_KEY",
+        "-e", "PANTHER_API_TOKEN",
         "--rm",
         "mcp-panther"
       ],
       "env": {
         "PANTHER_INSTANCE_URL": "https://YOUR-PANTHER-INSTANCE.domain",
-        "PANTHER_API_KEY": "YOUR-API-KEY"
+        "PANTHER_API_TOKEN": "YOUR-API-KEY"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,5 @@ addopts = "-v --cov=src/mcp_panther --cov-report=term-missing"
 pythonpath = ["src"]
 env = [
     "PANTHER_INSTANCE_URL=https://example.com",
-    "PANTHER_API_KEY=test-token"
+    "PANTHER_API_TOKEN=test-token"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "gql>=3.5.2",
     "mcp[cli]>=1.6.0",
     "pip-system-certs>=0.1.0",
-    "python-dotenv>=1.1.0",
     "click>=8.1.0",
     "uvicorn>=0.24.0",
     "starlette>=0.35.0",

--- a/src/mcp_panther/panther_mcp_core/client.py
+++ b/src/mcp_panther/panther_mcp_core/client.py
@@ -50,9 +50,9 @@ async def get_json_from_script_tag(
 
 def get_panther_api_key() -> str:
     """Get Panther API key from environment variable"""
-    api_key = os.getenv("PANTHER_API_KEY")
+    api_key = os.getenv("PANTHER_API_TOKEN")
     if not api_key:
-        raise ValueError("PANTHER_API_KEY environment variable is not set")
+        raise ValueError("PANTHER_API_TOKEN environment variable is not set")
     return api_key
 
 

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -6,13 +6,9 @@ import sys
 
 import click
 import uvicorn
-from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from starlette.routing import Mount
-
-# Load environment variables from .env file if it exists
-load_dotenv()
 
 # Server name
 MCP_SERVER_NAME = "mcp-panther"
@@ -46,7 +42,6 @@ except ImportError:
 
 # Server dependencies
 deps = [
-    "python-dotenv",
     "gql[aiohttp]",
     "aiohttp",
     "mcp[cli]",

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,6 @@ dependencies = [
     { name = "gql" },
     { name = "mcp", extra = ["cli"] },
     { name = "pip-system-certs" },
-    { name = "python-dotenv" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -381,7 +380,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.1.1" },
-    { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.2" },
     { name = "starlette", specifier = ">=0.35.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },


### PR DESCRIPTION
### Description

Having multiple entry points for credentials was causing headaches when updating instances and tokens. This change removes dotenv, which also simplifies the calls to run `mcp-panther`.

This PR also changes the PANTHER_API_KEY var to be consistent with the Console's API_TOKEN terminology.

### References

None

### Checklist

- [X] Added unit tests (N/A)
- [X] Tested end-to-end, including screenshots or videos

### Testing

Tested end-to-end in Claude Desktop ✅ 