### PR TITLE
Alert Reporting and Triage Prompts/Tools

### DIFF
--- a/.prd/REQUIREMENTS.txt
+++ b/.prd/REQUIREMENTS.txt
@@ -1,3 +1,0 @@
-# MCP Server Functionality
-
-#TODO

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -33,23 +33,3 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
     5. End with prioritized recommendations for investigation based on the entity groups, not just alert severity.
 
 Format your response with clear markdown headings for each entity group and use concise, cybersecurity-nuanced language."""
-
-
-@mcp_prompt
-def get_alerts_by_timeframe(start_date: str, end_date: str) -> str:
-    """Get a simple list of alerts created within a specified time period.
-
-    Args:
-        start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
-        end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
-    """
-    return f"""You are an expert in cybersecurity, SIEM, and attacker techniques.
-
-List all non-INFO-level alerts created between {start_date} and {end_date}. Format the results in a markdown table with the following columns:
-1. Alert ID
-2. Title
-3. Severity
-4. Creation time
-5. Status
-
-Sort the alerts by creation time (newest first) and group them by severity."""

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -16,7 +16,7 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
     return f"""Analyze alert signals and group them based on entity names. The goal is to identify patterns of related activity across alerts and triage them together.
 
 1. Get all alert IDs between {start_date} and {end_date} with the list_alerts tool
-2. Get stats on all alert events with the get_alert_summaries tool
+2. Get stats on all alert events with the get_alert_event_summaries tool
 3. Group alerts by entity names, combining similar alerts together
 4. For each group:
     1. Identify the common entity name performing the actions

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -28,21 +28,27 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
         start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
         end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
     """
-    return f"""Analyze Temporal Alert Data between {start_date} and {end_date}, grouping them logically based on actor patterns rather than just by severity or rule type. For each group:
+    return f"""Analyze Temporal Alerts and group them logically based on actor patterns rather than just by severity or rule type.
 
-1. Identify the common actor or entity performing the actions
-2. Summarize the activity pattern across all related alerts
-3. Include key details such as:
-   - Rule IDs triggered
-   - Timeframes of activity
-   - Source IPs and usernames involved
-   - Systems or platforms affected
+1. Get all alert IDs between {start_date} and {end_date} with the list_alerts tool
+2. Get stats on all alert events with the get_temporal_alert_groups tool
+3. Group alerts by actor patterns
+4. For each group:
+    1. Identify the common actor or entity performing the actions
 
-4. Provide a brief assessment of whether the activity appears to be:
-   - Expected system behavior
-   - Legitimate user activity
-   - Suspicious or concerning behavior requiring investigation
+    2. Summarize the activity pattern across all related alerts
 
-5. End with prioritized recommendations for investigation based on the actor groups, not just alert severity.
+    3. Include key details such as:
+    - Rule IDs triggered
+    - Timeframes of activity
+    - Source IPs and usernames involved
+    - Systems or platforms affected
+
+    4. Provide a brief assessment of whether the activity appears to be:
+    - Expected system behavior
+    - Legitimate user activity
+    - Suspicious or concerning behavior requiring investigation
+
+    5. End with prioritized recommendations for investigation based on the actor groups, not just alert severity.
 
 Format your response with clear headings for each actor group and use concise, security-focused language."""

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -6,21 +6,6 @@ from .registry import mcp_prompt
 
 
 @mcp_prompt
-def triage_alert(alert_id: str) -> str:
-    """
-    Generate a prompt for triaging a specific Panther alert.
-
-    Args:
-        alert_id: The ID of the alert to triage
-    """
-    return f"""You are an expert cyber security analyst. Follow these steps to triage a Panther alert:
-    1. Get the alert details for alert ID {alert_id}
-    2. Query the data lake to read all associated events (database: panther_rule_matches.public, table: log type from the alert)
-    3. Determine alert judgment based on common attacker patterns and techniques (benign, false positive, true positive, or a custom judgment).
-    """
-
-
-@mcp_prompt
 def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
     """Get temporal alert data between specified dates and perform detailed actor-based analysis and prioritization.
 
@@ -52,3 +37,23 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
     5. End with prioritized recommendations for investigation based on the actor groups, not just alert severity.
 
 Format your response with clear headings for each actor group and use concise, security-focused language."""
+
+
+@mcp_prompt
+def get_alerts_by_timeframe(start_date: str, end_date: str) -> str:
+    """Get a simple list of alerts created within a specified time period.
+
+    Args:
+        start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
+        end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
+    """
+    return f"""List all alerts created between {start_date} and {end_date}.
+
+Format the results in a table with the following columns:
+1. Alert ID
+2. Title
+3. Severity
+4. Creation time
+5. Status
+
+Sort the alerts by creation time (newest first) and group them by severity."""

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -13,30 +13,26 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
         start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
         end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
     """
-    return f"""Analyze Temporal Alerts and group them logically based on actor patterns rather than just by severity or rule type.
+    return f"""Analyze alert signals and group them based on entity names. The goal is to identify patterns of related activity across alerts and triage them together.
 
 1. Get all alert IDs between {start_date} and {end_date} with the list_alerts tool
-2. Get stats on all alert events with the get_temporal_alert_groups tool
-3. Group alerts by actor patterns
+2. Get stats on all alert events with the get_alert_summaries tool
+3. Group alerts by entity names, combining similar alerts together
 4. For each group:
-    1. Identify the common actor or entity performing the actions
-
+    1. Identify the common entity name performing the actions
     2. Summarize the activity pattern across all related alerts
-
     3. Include key details such as:
     - Rule IDs triggered
     - Timeframes of activity
     - Source IPs and usernames involved
     - Systems or platforms affected
-
     4. Provide a brief assessment of whether the activity appears to be:
     - Expected system behavior
     - Legitimate user activity
     - Suspicious or concerning behavior requiring investigation
+    5. End with prioritized recommendations for investigation based on the entity groups, not just alert severity.
 
-    5. End with prioritized recommendations for investigation based on the actor groups, not just alert severity.
-
-Format your response with clear headings for each actor group and use concise, security-focused language."""
+Format your response with clear markdown headings for each entity group and use concise, cybersecurity-nuanced language."""
 
 
 @mcp_prompt
@@ -47,9 +43,9 @@ def get_alerts_by_timeframe(start_date: str, end_date: str) -> str:
         start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
         end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
     """
-    return f"""List all alerts created between {start_date} and {end_date}.
+    return f"""You are an expert in cybersecurity, SIEM, and attacker techniques.
 
-Format the results in a table with the following columns:
+List all non-INFO-level alerts created between {start_date} and {end_date}. Format the results in a markdown table with the following columns:
 1. Alert ID
 2. Title
 3. Severity

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -15,9 +15,9 @@ def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
     """
     return f"""Analyze alert signals and group them based on entity names. The goal is to identify patterns of related activity across alerts and triage them together.
 
-1. Get all alert IDs between {start_date} and {end_date} with the list_alerts tool
-2. Get stats on all alert events with the get_alert_event_summaries tool
-3. Group alerts by entity names, combining similar alerts together
+1. Get all alert IDs between {start_date} and {end_date}.
+2. Get stats on all alert events with the get_alert_event_summaries tool.
+3. Group alerts by entity names, combining similar alerts together.
 4. For each group:
     1. Identify the common entity name performing the actions
     2. Summarize the activity pattern across all related alerts

--- a/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/alert_triage.py
@@ -12,9 +12,6 @@ def triage_alert(alert_id: str) -> str:
 
     Args:
         alert_id: The ID of the alert to triage
-
-    Returns:
-        A prompt string for guiding the user through alert triage
     """
     return f"""You are an expert cyber security analyst. Follow these steps to triage a Panther alert:
     1. Get the alert details for alert ID {alert_id}
@@ -24,15 +21,28 @@ def triage_alert(alert_id: str) -> str:
 
 
 @mcp_prompt
-def prioritize_and_triage_alerts() -> str:
-    """
-    Generate a prompt for prioritizing and triaging multiple Panther alerts.
+def list_and_prioritize_alerts(start_date: str, end_date: str) -> str:
+    """Get temporal alert data between specified dates and perform detailed actor-based analysis and prioritization.
 
-    Returns:
-        A prompt string for guiding the user through alert prioritization and triage
+    Args:
+        start_date: The start date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
+        end_date: The end date in format "YYYY-MM-DD HH:MM:SSZ" (e.g. "2025-04-22 22:37:41Z")
     """
-    return """You are an expert cyber security analyst. Your goal is to prioritize alerts based on severity, impact, and other relevant criteria to decide which alerts to investigate first. Use the following steps to prioritize alerts:
-    1. List all alerts in the last 7 days excluding severities LOW, and logically group them by user, host, or other similar criteria. Alerts can be related even if they have different titles or log types (for example, if a user logs into Okta and then AWS).
-    2. Triage each group of alerts to understand what happened and what the impact was. Query the data lake to read all associated events (database: panther_rule_matches.public, table: log type from the alert) and use the results to understand the impact.
-    3. For each group, if the alerts are false positives, suggest a rule improvement by reading the Python source, comment on the alert with your analysis, and mark the alert as invalid. If the alerts are true positives, begin pivoting on the available data to understand the root cause and impact.
-    """
+    return f"""Analyze Temporal Alert Data between {start_date} and {end_date}, grouping them logically based on actor patterns rather than just by severity or rule type. For each group:
+
+1. Identify the common actor or entity performing the actions
+2. Summarize the activity pattern across all related alerts
+3. Include key details such as:
+   - Rule IDs triggered
+   - Timeframes of activity
+   - Source IPs and usernames involved
+   - Systems or platforms affected
+
+4. Provide a brief assessment of whether the activity appears to be:
+   - Expected system behavior
+   - Legitimate user activity
+   - Suspicious or concerning behavior requiring investigation
+
+5. End with prioritized recommendations for investigation based on the actor groups, not just alert severity.
+
+Format your response with clear headings for each actor group and use concise, security-focused language."""

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -27,8 +27,8 @@ logger = logging.getLogger("mcp-panther")
 async def list_alerts(
     start_date: str = None,
     end_date: str = None,
-    severities: List[str] = None,
-    statuses: List[str] = None,
+    severities: List[str] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+    statuses: List[str] = ["OPEN", "TRIAGED", "RESOLVED", "CLOSED"],
     cursor: str = None,
     detection_id: str = None,
     event_count_max: int = None,

--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -23,11 +23,11 @@ logger = logging.getLogger("mcp-panther")
 
 
 @mcp_tool
-async def get_alert_summaries(alert_ids: list[str], time_window: int = 30):
-    """Gather a summary of multiple alerts based on their IDs, which is helpful for prioritizing alerts and identifying relationships.
+async def get_alert_event_summaries(alert_ids: list[str], time_window: int = 30):
+    """Gather a summary of one or more alert's events. This is helpful for prioritizing and identifying relationships.
 
-    This tool gathers important fields from alerts that occurred in the same time window.
-    It takes a list of alert IDs and groups them by day, a time bucket, log type, source IP, email, username, and trace ID to find patterns of related activity.
+    This tool gathers stats on p_ fields from alerts that occurred within a shared time window.
+    It takes a list of alert IDs and groups them by day, a time bucket, log type, source IPs, emails, usernames, and trace IDs to identify patterns of related activity.
     For each group, it counts alerts, collects alert IDs, rule IDs, timestamps, and severity levels, then sorts the results chronologically with the most recent events first.
 
     Args:

--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -23,6 +23,83 @@ logger = logging.getLogger("mcp-panther")
 
 
 @mcp_tool
+async def get_temporal_alert_groups(
+    start_date: datetime, end_date: datetime, time_window: int = 30
+):
+    """Gather a summary of multiple alerts within a given date range. This is helpful for prioritizing alerts and identifying relationships.
+
+    This tool performs alert correlation by identifying related security events that occur in the same specific time window.
+    It takes security alerts between the specified dates and groups them by day, a time bucket, log type, source IP, email, and username to find patterns of related activity.
+    For each group, it counts alerts, collects alert IDs, rule IDs, timestamps, and severity levels, then sorts the results chronologically with the most recent events first.
+
+    Args:
+        start_date: The start date as a datetime object
+        end_date: The end date as a datetime object
+        time_window: The time window in minutes to group distinct events by (must be 1, 5, 15, 30, or 60)
+
+    Example:
+        start = datetime(2025, 4, 22, 22, 37, 41)  # 2025-04-22 22:37:41Z
+    """
+    if time_window not in [1, 5, 15, 30, 60]:
+        raise ValueError("Time window must be 1, 5, 15, 30, or 60")
+
+    # Convert datetime objects to the required format: YYYY-MM-DD HH:MM:SSZ
+    start_date_str = start_date.strftime("%Y-%m-%d %H:%M:%SZ")
+    end_date_str = end_date.strftime("%Y-%m-%d %H:%M:%SZ")
+
+    query = f"""
+WITH alert_data AS (
+    SELECT
+        alertId,
+        title,
+        severity,
+        detectionId,
+        detectionDisplayName,
+        firstEventTime,
+        creationTime
+    FROM
+        panther_signals.public.signal_alerts
+    WHERE
+        p_occurs_between('{start_date_str}', '{end_date_str}')
+)
+
+SELECT
+    DATE_TRUNC('DAY', cs.p_event_time) AS event_day,
+    DATE_TRUNC('MINUTE', DATEADD('MINUTE', {time_window} * FLOOR(EXTRACT(MINUTE FROM cs.p_event_time) / {time_window}), 
+        DATE_TRUNC('HOUR', cs.p_event_time))) AS time_{time_window}_minute,
+    cs.p_log_type,
+    cs.p_any_ip_addresses AS source_ips,
+    cs.p_any_emails AS emails,
+    cs.p_any_usernames AS usernames,
+    COUNT(DISTINCT cs.p_alert_id) AS alert_count,
+    ARRAY_AGG(DISTINCT cs.p_alert_id) AS alert_ids,
+    ARRAY_AGG(DISTINCT cs.p_rule_id) AS rule_ids,
+    MIN(cs.p_event_time) AS first_event,
+    MAX(cs.p_event_time) AS last_event,
+    LISTAGG(DISTINCT a.severity, ', ') AS severities
+FROM
+    panther_signals.public.correlation_signals cs
+JOIN
+    alert_data a ON cs.p_alert_id = a.alertId
+GROUP BY
+    event_day,
+    time_{time_window}_minute,
+    cs.p_log_type,
+    cs.p_any_ip_addresses,
+    cs.p_any_emails,
+    cs.p_any_usernames
+HAVING
+    COUNT(DISTINCT cs.p_alert_id) > 0
+ORDER BY
+    event_day DESC,
+    time_{time_window}_minute DESC,
+    alert_count DESC
+LIMIT 1000
+"""
+    return await execute_data_lake_query(query, "panther_signals.public")
+
+
+@mcp_tool
 async def execute_data_lake_query(
     sql: str, database_name: Optional[str] = "panther_logs.public"
 ) -> Dict[str, Any]:

--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -23,11 +23,11 @@ logger = logging.getLogger("mcp-panther")
 
 
 @mcp_tool
-async def get_temporal_alert_groups(alert_ids: list[str], time_window: int = 30):
-    """Gather a summary of multiple alerts based on their IDs. This is helpful for prioritizing alerts and identifying relationships.
+async def get_alert_summaries(alert_ids: list[str], time_window: int = 30):
+    """Gather a summary of multiple alerts based on their IDs, which is helpful for prioritizing alerts and identifying relationships.
 
-    This tool performs alert correlation by identifying related security events that occur in the same specific time window.
-    It takes a list of alert IDs and groups them by day, a time bucket, log type, source IP, email, and username to find patterns of related activity.
+    This tool gathers important fields from alerts that occurred in the same time window.
+    It takes a list of alert IDs and groups them by day, a time bucket, log type, source IP, email, username, and trace ID to find patterns of related activity.
     For each group, it counts alerts, collects alert IDs, rule IDs, timestamps, and severity levels, then sorts the results chronologically with the most recent events first.
 
     Args:
@@ -52,6 +52,7 @@ SELECT
     cs.p_any_ip_addresses AS source_ips,
     cs.p_any_emails AS emails,
     cs.p_any_usernames AS usernames,
+    cs.p_any_trace_ids AS trace_ids,
     COUNT(DISTINCT cs.p_alert_id) AS alert_count,
     ARRAY_AGG(DISTINCT cs.p_alert_id) AS alert_ids,
     ARRAY_AGG(DISTINCT cs.p_rule_id) AS rule_ids,
@@ -68,7 +69,8 @@ GROUP BY
     cs.p_log_type,
     cs.p_any_ip_addresses,
     cs.p_any_emails,
-    cs.p_any_usernames
+    cs.p_any_usernames,
+    cs.p_any_trace_ids
 HAVING
     COUNT(DISTINCT cs.p_alert_id) > 0
 ORDER BY

--- a/src/mcp_panther/panther_mcp_core/tools/metrics.py
+++ b/src/mcp_panther/panther_mcp_core/tools/metrics.py
@@ -3,7 +3,7 @@ Tools for interacting with Panther metrics.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..client import _execute_query, _get_today_date_range
 from ..queries import METRICS_ALERTS_PER_RULE_QUERY, METRICS_ALERTS_PER_SEVERITY_QUERY
@@ -16,14 +16,16 @@ logger = logging.getLogger("mcp-panther")
 async def get_metrics_alerts_per_severity(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
-    interval_in_minutes: Optional[int] = 60,  # Default to 1 hour
+    alert_types: Optional[List[str]] = ["Rule"],
+    severities: Optional[List[str]] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+    interval_in_minutes: Optional[int] = 1440,
 ) -> Dict[str, Any]:
-    """Get quick metric counts of alerts grouped by severity over time.
+    """Get metrics alert counts grouped by severity. Defaults to today. Use this tool when you want to get a count of alerts by severity, alert type, or both for a given time period.
 
     Args:
         from_date: Optional start date in ISO 8601 format (e.g. "2024-03-20T00:00:00Z")
         to_date: Optional end date in ISO 8601 format (e.g. "2024-03-21T00:00:00Z")
-        interval_in_minutes: Optional interval between metric checks (for plotting charts). Defaults to 60 minutes (1 hour).
+        interval_in_minutes: The grouping interval for the metrics. Defaults to 1440 minutes (1 day) for daily metrics but can be set to 60 minutes (1 hour) for hourly metrics.
 
     Returns:
         Dict containing:
@@ -61,9 +63,17 @@ async def get_metrics_alerts_per_severity(
 
         metrics_data = result["metrics"]
 
+        # Filter metrics data by alert types and severities
+        alerts_per_severity = [
+            item
+            for item in metrics_data["alertsPerSeverity"]
+            if any(alert_type in item["label"] for alert_type in alert_types)
+            and any(severity in item["label"] for severity in severities)
+        ]
+
         return {
             "success": True,
-            "alerts_per_severity": metrics_data["alertsPerSeverity"],
+            "alerts_per_severity": alerts_per_severity,
             "total_alerts": metrics_data["totalAlerts"],
             "from_date": from_date,
             "to_date": to_date,
@@ -83,13 +93,15 @@ async def get_metrics_alerts_per_rule(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
     interval_in_minutes: Optional[int] = 60,  # Default to 1 hour
+    rule_ids: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
-    """Get quick metric counts of alerts grouped by rule over time.
+    """Returns the number of created alerts per rule during the given time period. Includes all non-error rule types like rules, scheduled rules, and policies. Use this tool when you want to get a count of alerts by rule for a given time period.
 
     Args:
         from_date: Optional start date in ISO 8601 format (e.g. "2024-03-20T00:00:00Z")
         to_date: Optional end date in ISO 8601 format (e.g. "2024-03-21T00:00:00Z")
         interval_in_minutes: Optional interval between metric checks (for plotting charts). Defaults to 60 minutes (1 hour).
+        rule_ids: Optional list of rule IDs to filter results by. If not provided, returns all rules.
 
     Returns:
         Dict containing:
@@ -125,9 +137,19 @@ async def get_metrics_alerts_per_rule(
 
         metrics_data = result["metrics"]
 
+        # Filter by rule IDs if provided
+        if rule_ids:
+            alerts_per_rule = [
+                item
+                for item in metrics_data["alertsPerRule"]
+                if item["entityId"] in rule_ids
+            ]
+        else:
+            alerts_per_rule = metrics_data["alertsPerRule"]
+
         return {
             "success": True,
-            "alerts_per_rule": metrics_data["alertsPerRule"],
+            "alerts_per_rule": alerts_per_rule,
             "total_alerts": metrics_data["totalAlerts"],
             "from_date": from_date,
             "to_date": to_date,

--- a/src/mcp_panther/panther_mcp_core/tools/metrics.py
+++ b/src/mcp_panther/panther_mcp_core/tools/metrics.py
@@ -92,7 +92,7 @@ async def get_metrics_alerts_per_severity(
 async def get_metrics_alerts_per_rule(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
-    interval_in_minutes: Optional[int] = 60,  # Default to 1 hour
+    interval_in_minutes: Optional[int] = 1440,  # Default to 1 day
     rule_ids: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Returns the number of created alerts per rule during the given time period. Includes all non-error rule types like rules, scheduled rules, and policies. Use this tool when you want to get a count of alerts by rule for a given time period.
@@ -100,13 +100,16 @@ async def get_metrics_alerts_per_rule(
     Args:
         from_date: Optional start date in ISO 8601 format (e.g. "2024-03-20T00:00:00Z")
         to_date: Optional end date in ISO 8601 format (e.g. "2024-03-21T00:00:00Z")
-        interval_in_minutes: Optional interval between metric checks (for plotting charts). Defaults to 60 minutes (1 hour).
+        interval_in_minutes: Optional interval between metric checks (for plotting charts). Defaults to 1440 minutes (1 day).
         rule_ids: Optional list of rule IDs to filter results by. If not provided, returns all rules.
 
     Returns:
         Dict containing:
-        - alerts_per_rule: List of series with rule IDs and alert counts
+        - alerts_per_rule: List of series with breakdown by rule
         - total_alerts: Total number of alerts in the period
+        - from_date: Start date of the period
+        - to_date: End date of the period
+        - interval_in_minutes: Grouping interval for the metrics
     """
     try:
         # If no dates provided, get today's date range


### PR DESCRIPTION
### Description

This change allows users to easily browse alert trends, create reports, and automatically group related alerts for faster triage.

#### Changes
- Make the `list_alerts` and related metrics tools ignore INFO-level alerts by default. It clouds the results.
- Add a new `get_alert_event_summaries` tool, which returns summaries across all events in a given alert cohort.
- Add more robust parameters to the `metrics` tools for better performance and quality of results.
- Adds a new prompt called `list_and_prioritize_alerts` to assist in getting started with daily triage.

### References

None

### Checklist

- [ ] Added unit tests
- [X] Tested end-to-end, including screenshots or videos

### Testing

#### `list_and_prioritize_alerts`
![Screenshot 2025-05-08 at 8 54 04 AM](https://github.com/user-attachments/assets/3778b4d8-7abf-4304-82ca-53e8738cc6f6)

#### `get_metrics_alerts_per_severity`
![Screenshot 2025-05-08 at 8 39 18 AM](https://github.com/user-attachments/assets/b3f0520e-ba1e-48b4-a69f-63cfa23346a3)

#### `get_metrics_alerts_per_rule`
![Screenshot 2025-05-08 at 8 53 25 AM](https://github.com/user-attachments/assets/9ec19a23-90a2-45c0-9a16-fec9c89f4c3d)
![Screenshot 2025-05-08 at 8 53 33 AM](https://github.com/user-attachments/assets/69dc51ad-c470-4139-b3b2-54c7e552a03a)
