### PR TITLE
tool: get metrics query for processed bytes

### DIFF
--- a/src/mcp_panther/panther_mcp_core/queries.py
+++ b/src/mcp_panther/panther_mcp_core/queries.py
@@ -346,6 +346,18 @@ query Metrics($input: MetricsInput!) {
 }
 """)
 
+METRICS_BYTES_PROCESSED_QUERY = gql("""
+query GetBytesProcessedMetrics($input: MetricsInput!) {
+    metrics(input: $input) {
+        bytesProcessedPerSource {
+            label
+            value
+            breakdown
+        }
+    }
+}
+""")
+
 GET_SCHEMA_DETAILS_QUERY = gql("""
 query GetSchemaDetails($name: String!) {
     schemas(input: { name: $name }) {

--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -94,6 +94,7 @@ async def execute_data_lake_query(
     REQUIREMENTS:
     1. USE THE get_table_columns TOOL FIRST to get the correct table schema.
     2. THE QUERY MUST INCLUDE A FILTER ON p_event_time WITH A MAX TIME DURATION OF 90 DAYS.
+    3. Check the size of the table with get_bytes_processed_per_log_type_and_source. If the table is large, use smaller time windows and more specific filters.
 
     NOTE: After calling this function, you MUST call get_data_lake_query_results with the
     returned query_id to retrieve the actual query results.


### PR DESCRIPTION
### Description

This new tool aims to help the LLM know how much data is actively sent into the SIEM to gauge how large a resultant table may be. For example, specific queries require precise filtering based on partitions for performance, but if the table is not accumulating as much data, we can be more lenient. 

### References

None

### Checklist

- [X] Added unit tests
- [X] Tested end-to-end, including screenshots or videos

![Screenshot 2025-05-13 at 7 51 31 AM](https://github.com/user-attachments/assets/0fb2b8ef-29ba-4d3f-9793-6d421e0aa284)
![Screenshot 2025-05-13 at 7 51 24 AM](https://github.com/user-attachments/assets/b88def19-e974-499d-add7-0662036dd01d)

### Notes for Reviewing

Nothing special
