### PR TITLE
[bug] fix gql getschemadetails query

### DIFF
--- a/src/mcp_panther/panther_mcp_core/queries.py
+++ b/src/mcp_panther/panther_mcp_core/queries.py
@@ -360,7 +360,7 @@ query GetBytesProcessedMetrics($input: MetricsInput!) {
 
 GET_SCHEMA_DETAILS_QUERY = gql("""
 query GetSchemaDetails($name: String!) {
-    schemas(input: { name: $name }) {
+    schemas(input: { contains: $name }) {
         edges {
             node {
                 name


### PR DESCRIPTION
### Description

The `get_log_type_schema_details` tool was erroring on:

```json
{
  "success": false,
  "message": "Failed to fetch schema details: Field 'name' is not defined by type 'SchemasInput'.\n\nGraphQL request:3:22\n2 | query GetSchemaDetails($name: String!) {\n3 |     schemas(input: { name: $name }) {\n  |                      ^\n4 |         edges {"
}
```

Unsure how this wasn't caught earlier... But it's now fixed.

<img width="951" alt="Screenshot 2025-05-13 at 11 45 59 AM" src="https://github.com/user-attachments/assets/d437b02b-304b-4355-ae3a-28b01e49704e" />

### References

None

### Checklist

- [ ] Added unit tests (N/A)
- [X] Tested end to end, including screenshots or videos

### Notes for Reviewing

None
