### PR TITLE
Add user agent to requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ FROM python:3.12-slim
 # Set working directory
 WORKDIR /app
 
+# Set environment variable to indicate Docker environment
+ENV MCP_PANTHER_DOCKER_RUNTIME=true
+
 # Copy only the installed packages and project files
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin/mcp-panther /usr/local/bin/mcp-panther

--- a/src/mcp_panther/panther_mcp_core/client.py
+++ b/src/mcp_panther/panther_mcp_core/client.py
@@ -140,7 +140,7 @@ def _is_running_in_docker() -> bool:
     Returns:
         bool: True if running in Docker, False otherwise
     """
-    return os.environ.get('MCP_PANTHER_DOCKER_RUNTIME') == 'true'
+    return os.environ.get("MCP_PANTHER_DOCKER_RUNTIME") == "true"
 
 
 def _get_user_agent() -> str:

--- a/src/mcp_panther/panther_mcp_core/client.py
+++ b/src/mcp_panther/panther_mcp_core/client.py
@@ -3,14 +3,17 @@ import json
 import logging
 import os
 import re
+from importlib.metadata import version
 from typing import Any, AnyStr, Dict, List, Optional, Tuple, Union
 
 import aiohttp
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 
+PACKAGE_NAME = "mcp-panther"
+
 # Get logger
-logger = logging.getLogger("mcp-panther")
+logger = logging.getLogger(PACKAGE_NAME)
 
 
 async def get_json_from_script_tag(
@@ -131,11 +134,28 @@ async def get_panther_gql_endpoint() -> str:
     return base + "/public/graphql"
 
 
+def _get_user_agent() -> str:
+    """Get the user agent string for API requests.
+
+    Returns:
+        str: User agent string in format '{PACKAGE_NAME}/{version} (Python)'
+    """
+    try:
+        package_version = version(PACKAGE_NAME)
+        return f"{PACKAGE_NAME}/{package_version} (Python)"
+    except Exception as e:
+        logger.debug(f"Failed to get package version: {e}")
+        return f"{PACKAGE_NAME}/development (Python)"
+
+
 async def _create_panther_client() -> Client:
     """Create a Panther GraphQL client with proper configuration"""
     transport = AIOHTTPTransport(
         url=await get_panther_gql_endpoint(),
-        headers={"X-API-Key": get_panther_api_key()},
+        headers={
+            "X-API-Key": get_panther_api_key(),
+            "User-Agent": _get_user_agent(),
+        },
         ssl=True,  # Enable SSL verification
     )
     return Client(transport=transport, fetch_schema_from_transport=True)
@@ -196,6 +216,7 @@ class PantherRestClient:
             self._headers = {
                 "X-API-Key": get_panther_api_key(),
                 "Content-Type": "application/json",
+                "User-Agent": _get_user_agent(),
             }
         return self
 

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -46,6 +46,7 @@ deps = [
     "aiohttp",
     "anyascii",
     "mcp[cli]",
+    "fastmcp",
 ]
 
 # Create the MCP server

--- a/tests/panther_mcp_core/test_client.py
+++ b/tests/panther_mcp_core/test_client.py
@@ -1,0 +1,41 @@
+import os
+from unittest import mock
+
+import pytest
+
+from mcp_panther.panther_mcp_core.client import _is_running_in_docker, _get_user_agent
+
+
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("true", True),
+        ("false", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_running_in_docker(env_value, expected):
+    """Test Docker environment detection with various environment variable values."""
+    with mock.patch.dict(os.environ, {"MCP_PANTHER_DOCKER_RUNTIME": env_value} if env_value is not None else {}):
+        assert _is_running_in_docker() == expected
+
+
+@pytest.mark.parametrize(
+    "docker_running,version,expected",
+    [
+        (True, "1.0.0", "mcp-panther/1.0.0 (Python; Docker)"),
+        (False, "1.0.0", "mcp-panther/1.0.0 (Python)"),
+        (True, None, "mcp-panther/development (Python; Docker)"),
+        (False, None, "mcp-panther/development (Python)"),
+    ],
+)
+def test_get_user_agent(docker_running, version, expected):
+    """Test user agent string generation with various conditions."""
+    # Mock version function
+    with mock.patch("mcp_panther.panther_mcp_core.client.version", return_value=version) if version else mock.patch(
+        "mcp_panther.panther_mcp_core.client.version", side_effect=Exception("Version not found")
+    ):
+        # Mock Docker detection
+        with mock.patch("mcp_panther.panther_mcp_core.client._is_running_in_docker", return_value=docker_running):
+            assert _get_user_agent() == expected 


### PR DESCRIPTION
### Description

This adds a user agent to requests. When installed as a package the version will be included, when running locally for development, it won't.

### References

Notice the `userAgent` string in the cloudwatch logs for both graphql and rest requests.

![Screenshot 2025-05-14 at 5 11 19 PM](https://github.com/user-attachments/assets/ba54374c-13cc-4ab6-b8db-a89a686576e5)

### Checklist

- [ ] Added unit tests
- [x] Tested end to end, including screenshots or videos

### Notes for Reviewing
