### PR TITLE
adds logic to support original parameters for tool, resource, and prompt annotations

### DIFF
--- a/src/mcp_panther/panther_mcp_core/prompts/registry.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/registry.py
@@ -5,7 +5,8 @@ This module provides functions for registering prompt templates with the MCP ser
 """
 
 import logging
-from typing import Callable, Set
+from functools import wraps
+from typing import Callable, Optional, Set
 
 logger = logging.getLogger("mcp-panther")
 
@@ -13,21 +14,60 @@ logger = logging.getLogger("mcp-panther")
 _prompt_registry: Set[Callable] = set()
 
 
-def mcp_prompt(func: Callable) -> Callable:
+def mcp_prompt(
+    func: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    tags: Optional[Set[str]] = None,
+) -> Callable:
     """
     Register a function as an MCP prompt template.
 
     Functions registered with this will be automatically added to the registry
     and can be registered with the MCP server using register_all_prompts().
 
-    Example:
+    Can be used in two ways:
+    1. Direct decoration:
         @mcp_prompt
         def triage_alert(alert_id: str) -> str:
             ...
-    """
-    _prompt_registry.add(func)
 
-    return func
+    2. With parameters:
+        @mcp_prompt(
+            name="Custom Triage",
+            description="Custom alert triage prompt",
+            tags={"triage", "alerts"}
+        )
+        def triage_alert(alert_id: str) -> str:
+            ...
+
+    Args:
+        func: The function to decorate
+        name: Optional name for the prompt
+        description: Optional description of the prompt
+        tags: Optional set of tags for the prompt
+    """
+
+    def decorator(func: Callable) -> Callable:
+        # Store metadata on the function
+        func._mcp_prompt_metadata = {
+            "name": name,
+            "description": description,
+            "tags": tags,
+        }
+        _prompt_registry.add(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    # Handle both @mcp_prompt and @mcp_prompt(...) cases
+    if func is None:
+        return decorator
+    return decorator(func)
 
 
 def register_all_prompts(mcp_instance) -> None:
@@ -41,7 +81,19 @@ def register_all_prompts(mcp_instance) -> None:
 
     for prompt in _prompt_registry:
         logger.debug(f"Registering prompt: {prompt.__name__}")
-        mcp_instance.prompt()(prompt)
+
+        # Get prompt metadata if it exists
+        metadata = getattr(prompt, "_mcp_prompt_metadata", {})
+
+        # Create prompt decorator with metadata
+        prompt_decorator = mcp_instance.prompt(
+            name=metadata.get("name"),
+            description=metadata.get("description"),
+            tags=metadata.get("tags"),
+        )
+
+        # Register the prompt
+        prompt_decorator(prompt)
 
     logger.info("All prompts registered successfully")
 
@@ -53,4 +105,4 @@ def get_available_prompt_names() -> list[str]:
     Returns:
         A list of the names of all registered prompts
     """
-    return [prompt.__name__ for prompt in _prompt_registry]
+    return sorted([prompt.__name__ for prompt in _prompt_registry])


### PR DESCRIPTION
## Description
This PR updates the MCP Registry Decorators to match the FastMCP annotation signatures

## Changes
- Updated `@mcp_resource` decorator to match FastMCP's `resource()` method signature:
  - Added support for optional parameters: `name`, `description`, `mime_type`, and `tags`
  - Renamed `resource_path` parameter to `uri` for consistency with FastMCP
  - Added metadata storage for registration

- Updated `@mcp_prompt` decorator to match FastMCP's `prompt()` method signature:
  - Added support for optional parameters: `name`, `description`, and `tags`
  - Added support for both direct decoration and parameter-based decoration
  - Added metadata storage for registration

## Testing
- ✅ Verified server continues to work in various modes
- ✅ Verified new parameters work (via integration test and viewing output)
   - also via the mcp inspector tool as well