### PR TITLE
Call Table Schema and Log Type Schema for Nested Object Queries

### DIFF
--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -197,11 +197,16 @@ async def execute_data_lake_query(
         "permissions": all_perms(Permission.DATA_ANALYTICS_READ),
     }
 )
-async def get_data_lake_query_results(query_id: str) -> Dict[str, Any]:
+async def get_data_lake_query_results(
+    query_id: Annotated[
+        str,
+        Field(
+            description="The ID of the query to get results for",
+            example="1234567890",
+        ),
+    ],
+) -> Dict[str, Any]:
     """Get the results of a previously executed data lake query.
-
-    Args:
-        query_id: The ID of the query to get results for
 
     Returns:
         Dict containing:
@@ -354,7 +359,15 @@ async def list_databases() -> Dict[str, Any]:
         "permissions": all_perms(Permission.DATA_ANALYTICS_READ),
     }
 )
-async def list_database_tables(database: str) -> Dict[str, Any]:
+async def list_database_tables(
+    database: Annotated[
+        str,
+        Field(
+            description="The name of the database to list tables for",
+            example="panther_logs.public",
+        ),
+    ],
+) -> Dict[str, Any]:
     """List all available tables in a Panther Database.
 
     Required: Only use valid database names obtained from list_databases
@@ -521,7 +534,15 @@ async def get_table_schema(
         "permissions": all_perms(Permission.DATA_ANALYTICS_READ),
     }
 )
-async def get_sample_log_events(log_type: str) -> Dict[str, Any]:
+async def get_sample_log_events(
+    schema_name: Annotated[
+        str,
+        Field(
+            description="The schema name to query for sample log events",
+            example="Panther.Audit",
+        ),
+    ],
+) -> Dict[str, Any]:
     """Get a sample of 10 log events for a specific log type from the panther_logs.public database.
 
     This function is the RECOMMENDED tool for quickly exploring sample log data with minimal effort.
@@ -534,21 +555,12 @@ async def get_sample_log_events(log_type: str) -> Dict[str, Any]:
 
     Example usage:
         # Step 1: Get query_id for sample events
-        result = get_sample_log_events(log_type="Panther.Audit")
+        result = get_sample_log_events(schema_name="Panther.Audit")
 
         # Step 2: Retrieve the actual results using the query_id
-        if result["success"]:
-            events = get_data_lake_query_results(query_id=result["query_id"])
+        events = get_data_lake_query_results(query_id=result["query_id"])
 
-            # Step 3: Display results in multiple formats for better analysis
-            # Display as a formatted table for human readability
-            display_table_format(events["results"])
-
-            # Optionally provide JSON format for deeper inspection
-            print(json.dumps(events["results"][0], indent=2))
-
-    Args:
-        log_type: The log type to query (this is also typically the table name)
+        # Step 3: Display results in a markdown table format
 
     Returns:
         Dict containing:
@@ -563,10 +575,10 @@ async def get_sample_log_events(log_type: str) -> Dict[str, Any]:
         3. Highlight key fields and patterns across records
     """
 
-    logger.info(f"Fetching sample log events for log type: {log_type}")
+    logger.info(f"Fetching sample log events for schema: {schema_name}")
 
     database_name = "panther_logs.public"
-    table_name = _normalize_name(log_type)
+    table_name = _normalize_name(schema_name)
 
     try:
         sql = f"""

--- a/src/mcp_panther/panther_mcp_core/tools/data_lake.py
+++ b/src/mcp_panther/panther_mcp_core/tools/data_lake.py
@@ -427,12 +427,34 @@ async def list_database_tables(database: str) -> Dict[str, Any]:
         "permissions": all_perms(Permission.DATA_ANALYTICS_READ),
     }
 )
-async def get_table_schema(database_name: str, table_name: str) -> Dict[str, Any]:
+async def get_table_schema(
+    database_name: Annotated[
+        str,
+        Field(
+            description="The name of the database where the table is located",
+            example="panther_logs.public",
+        ),
+    ],
+    table_name: Annotated[
+        str,
+        Field(
+            description="The name of the table to get columns for",
+            example="Panther.Audit",
+        ),
+    ],
+) -> Dict[str, Any]:
     """Get column details for a specific datalake table.
 
-    Args:
-        database_name: The name of the database where the table is located
-        table_name: The name of the table to get columns for
+    IMPORTANT: This returns the table structure in Snowflake/Redshift. For writing
+    optimal queries, ALSO call get_panther_log_type_schema() to understand:
+    - Nested object structures (only shown as 'object' type here)
+    - Which fields map to p_any_* indicator columns
+    - Array element structures
+
+    Example workflow:
+    1. get_panther_log_type_schema(["AWS.CloudTrail"]) - understand structure
+    2. get_table_schema("panther_logs.public", "aws_cloudtrail") - get column names/types
+    3. Write query using both: nested paths from log schema, column names from table schema
 
     Returns:
         Dict containing:

--- a/tests/panther_mcp_core/tools/test_data_lake.py
+++ b/tests/panther_mcp_core/tools/test_data_lake.py
@@ -21,7 +21,7 @@ async def test_get_sample_log_events_success(mock_graphql_client):
         "executeDataLakeQuery": {"id": MOCK_QUERY_ID}
     }
 
-    result = await get_sample_log_events("AWS.CloudTrail")
+    result = await get_sample_log_events(schema_name="AWS.CloudTrail")
 
     assert result["success"] is True
     assert result["query_id"] == MOCK_QUERY_ID
@@ -40,7 +40,7 @@ async def test_get_sample_log_events_error(mock_graphql_client):
     """Test handling of errors when getting sample log events."""
     mock_graphql_client.execute.side_effect = Exception("Test error")
 
-    result = await get_sample_log_events("AWS.CloudTrail")
+    result = await get_sample_log_events(schema_name="AWS.CloudTrail")
 
     assert result["success"] is False
     assert "Failed to execute data lake query" in result["message"]
@@ -53,7 +53,7 @@ async def test_get_sample_log_events_no_query_id(mock_graphql_client):
     """Test handling when no query ID is returned."""
     mock_graphql_client.execute.return_value = {}
 
-    result = await get_sample_log_events("AWS.CloudTrail")
+    result = await get_sample_log_events(schema_name="AWS.CloudTrail")
 
     assert result["success"] is False
     assert "No query ID returned" in result["message"]


### PR DESCRIPTION
### Description

Panther's Log Schema and Table Schema differ slightly in the amount of detail provided. It's common for tool calls for writing SQL to reference fields that don't exist due to a lack of knowledge. This change advises the LLM to get both the log type and table schema when writing queries for higher efficiency.

While implementing this change, I also:
1. Added annotations in the remainder data lake query tools for consistent/reliable tool calls
2. Updated the arg in sample logs to be specific about a schema_name to be consistent with our schema tools

### Checklist

- [x] Added unit tests
- [x] Tested end to end, including screenshots or videos

### Notes for Reviewing

<img width="791" alt="Screenshot 2025-05-27 at 11 53 39 AM" src="https://github.com/user-attachments/assets/1148efed-04a9-4f54-af7a-c055bedbddd2" />
