### PR TITLE
bump version to 1.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-panther"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "Panther Labs MCP Server"
 #readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
### Description
Preparation for real release. This sets our version to 1.0.0rc2 to verify all is good prior to making real release.

**Note**
Readme is deliberately commented out for now. We will uncomment that once we are ready for real release
