### PR TITLE
Policy Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ Panther's Model Context Protocol (MCP) server provides functionality to:
 | `create_rule` | Create a new Panther rule | "Create a new rule to detect more than 7 failed logins within a day across any user in the AWS Console" |
 | `disable_rule` | Disable a rule by setting enabled to false | "Disable rule abc123" |
 | `get_global_helper_by_id` | Get detailed information about a specific global helper | "Get details for global helper ID panther_github_helpers" |
+| `get_policy_by_id` | Get detailed information about a specific policy | "Get details for policy ID AWS.S3.Bucket.PublicReadACP" |
 | `get_rule_by_id` | Get detailed information about a specific rule | "Get details for rule ID abc123" |
 | `get_scheduled_rule_by_id` | Get detailed information about a specific scheduled rule | "Get details for scheduled rule abc123" |
 | `get_simple_rule_by_id` | Get detailed information about a specific simple rule | "Get details for simple rule abc123" |
 | `list_global_helpers` | List all Panther global helpers with optional pagination | "Show me all global helpers for CrowdStrike events" |
+| `list_policies` | List all Panther policies with optional pagination | "Show me all policies for AWS resources" |
 | `list_rules` | List all Panther rules with optional pagination | "Show me all enabled rules" |
 | `list_scheduled_rules` | List all scheduled rules with optional pagination | "List all scheduled rules in Panther" |
 | `list_simple_rules` | List all simple rules with optional pagination | "Show me all simple rules in Panther" |

--- a/src/README.md
+++ b/src/README.md
@@ -33,6 +33,36 @@ uv run fastmcp dev src/mcp_panther/server.py
 
 This command runs the server in development mode, which provides additional debugging information and automatically reloads when changes are detected.
 
+Or add the following to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "panther": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "fastmcp",
+        "--with",
+        "anyascii",
+        "--with",
+        "aiohttp",
+        "--with",
+        "gql[aiohttp]",
+        "fastmcp",
+        "run",
+        "/<PATH-TO-MCP-PANTHER-REPO>/src/mcp_panther/server.py"
+      ],
+      "env": {
+        "PANTHER_API_TOKEN": "<TOKEN-HERE>",
+        "PANTHER_INSTANCE_URL": "https://<INSTANCE-URL-HERE>"
+      }
+    }
+  }
+}
+```
+
 ### Debugging
 
 When running the server, you can set the logging level to DEBUG in `server.py` for more detailed logs:


### PR DESCRIPTION
### Description

Add tools for listing/getting policies. 

### Changes

_(Generated by Claude)_

  1. Added comprehensive rule listing support by implementing:
    - `list_policies()` and `get_policy_by_id()` tools for Panther policies
    - These joined the existing list_rules(), list_simple_rules(), and list_scheduled_rules() tools
  2. Fixed the URL construction issue that was causing the "None/policies" error by:
    - Improving error handling in the `PantherRestClient._build_url()` method
    - Adding better fallback logic in `get_instance_config()` for various exception types
    - Now users get a clear error message: "Panther REST API base URL not set. Please check your PANTHER_INSTANCE_URL environment variable or ensure the Panther instance is accessible."
  3. Added comprehensive test coverage for all the new policy functionality
  4. Updated documentation in the README.md to include the new policy tools

### Checklist

- [X] Added unit tests
- [X] Tested end-to-end, including screenshots or videos

### Notes for Reviewing

On the client changes, I hit an odd side-effect where when I loaded Claude Desktop and attempted to list policies, it returned `  "message": "Failed to fetch policies: None/policies"`. Claude added error handling, but it worked once I restarted Claude Desktop. This was an ephemeral issue where the env variables weren't correctly set on the first run (I think). We can remove it if we want.

<img width="782" alt="Screenshot 2025-06-02 at 4 06 09 PM" src="https://github.com/user-attachments/assets/94bb1954-9766-4f02-8384-f7ea3c97c634" />
<img width="792" alt="Screenshot 2025-06-02 at 4 06 04 PM" src="https://github.com/user-attachments/assets/2d90fc80-338b-42ad-96f1-20b0bdc5e9fa" />
