### PR TITLE
Add log file option for server logging (#1)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -74,6 +74,9 @@ logging.basicConfig(
     stream=sys.stderr,
 )
 ```
+To send logs to a file instead, run the server with `--log-file <path>` or set the
+`MCP_LOG_FILE` environment variable. Logs from FastMCP will also be written to the
+configured file.
 
 ### Run the Development Server
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,20 @@
+import logging
+
+from mcp_panther.server import configure_logging, logger
+
+
+def test_configure_logging_file(tmp_path):
+    log_file = tmp_path / "out.log"
+    configure_logging(str(log_file), force=True)
+    logger.setLevel(logging.INFO)
+    logger.info("test message")
+    fast_logger = logging.getLogger("FastMCP.test")
+    fast_logger.setLevel(logging.INFO)
+    fast_logger.info("fast message")
+    logging.shutdown()
+    data = log_file.read_text()
+    assert "test message" in data
+    assert "fast message" in data
+    # reset to stderr to avoid side effects
+    configure_logging(force=True)
+    logger.setLevel(logging.WARNING)


### PR DESCRIPTION
Add option to allow all logging to be routed to a file. Useful when running the MCP server in stdout form, inside of another process, where stdout can pollute the calling process's output.