### PR TITLE
repo: update code-quality workflow to handle forks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -36,6 +36,7 @@ jobs:
           uv pip install --system ruff
 
       - name: Import GPG key
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
@@ -44,7 +45,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Format and fix code
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           ruff format src
           ruff check --fix src


### PR DESCRIPTION
### Description
Noticed that code quality checks fail when a contributor forks repo. Adjusting our auto commit action to only go into effect if the PR is made directly against the repo.



### Checklist
- [x] Tested end to end, including screenshots or videos
   - [see job from forked repo that worked](https://github.com/panther-labs/mcp-panther/actions/runs/15445581226/job/43474186683)
   - https://github.com/panther-labs/mcp-panther/pull/83
   - [see original job that broke](https://github.com/panther-labs/mcp-panther/actions/runs/15430244015/job/43471621735)
   


