### PR TITLE
refactor: fixup CI code quality check

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # For pull requests, use the PR head ref.
+          # For pushes, this will be empty and default to the pushed branch.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+          # For pull requests from forks, we need to use the GITHUB_TOKEN.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -29,7 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache: true
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Description

We updated the code quality CI check in #82, needed to accommodate PRs against this repository from forks. Github events are tricky and each event trigger has a unique payload, leading to footguns like this. [Event docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows)  



From the [Github Context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) article:
`github.head_ref` | `string` | `The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.`
-- | -- | --

**Changes**
- corrected cache key on uv GHA
- added passing a ref to `checkout` conditionally

### References
n/a

### Checklist

~~- [ ] Added unit tests~~
~~- [ ] Tested end to end, including screenshots or videos~~

[x] Successful [code quality run](https://github.com/panther-labs/mcp-panther/actions/runs/15470666268/job/43553930657?pr=86) from fork PR #86 

### Notes for Reviewing

Checkout the successful run and PR above
