### PR TITLE
Remove implicit optionals

### DIFF
--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -30,20 +30,20 @@ logger = logging.getLogger("mcp-panther")
     }
 )
 async def list_alerts(
-    start_date: str = None,
-    end_date: str = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     severities: List[str] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
     statuses: List[str] = ["OPEN", "TRIAGED", "RESOLVED", "CLOSED"],
-    cursor: str = None,
-    detection_id: str = None,
-    event_count_max: int = None,
-    event_count_min: int = None,
-    log_sources: List[str] = None,
-    log_types: List[str] = None,
-    name_contains: str = None,
+    cursor: str | None = None,
+    detection_id: str | None = None,
+    event_count_max: int | None = None,
+    event_count_min: int | None = None,
+    log_sources: List[str] | None = None,
+    log_types: List[str] | None = None,
+    name_contains: str | None = None,
     page_size: int = 25,  # Default to 25, max is 50
-    resource_types: List[str] = None,
-    subtypes: List[str] = None,
+    resource_types: List[str] | None = None,
+    subtypes: List[str] | None = None,
     alert_type: str = "ALERT",  # Defaults to ALERT per schema
 ) -> Dict[str, Any]:
     """List alerts from Panther with comprehensive filtering options

--- a/src/mcp_panther/panther_mcp_core/tools/helpers.py
+++ b/src/mcp_panther/panther_mcp_core/tools/helpers.py
@@ -62,7 +62,9 @@ async def get_global_helper_by_id(helper_id: str) -> Dict[str, Any]:
         "permissions": any_perms(Permission.RULE_READ, Permission.POLICY_READ),
     }
 )
-async def list_global_helpers(cursor: str = None, limit: int = 100) -> Dict[str, Any]:
+async def list_global_helpers(
+    cursor: str | None = None, limit: int = 100
+) -> Dict[str, Any]:
     """List all global helpers from Panther with optional pagination
 
     Args:

--- a/src/mcp_panther/panther_mcp_core/tools/rules.py
+++ b/src/mcp_panther/panther_mcp_core/tools/rules.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("mcp-panther")
         "permissions": all_perms(Permission.RULE_READ),
     }
 )
-async def list_rules(cursor: str = None, limit: int = 100) -> Dict[str, Any]:
+async def list_rules(cursor: str | None = None, limit: int = 100) -> Dict[str, Any]:
     """List all rules from your Panther instance.
 
     Args:
@@ -165,7 +165,9 @@ async def disable_rule(rule_id: str) -> Dict[str, Any]:
         "permissions": all_perms(Permission.RULE_READ),
     }
 )
-async def list_scheduled_rules(cursor: str = None, limit: int = 100) -> Dict[str, Any]:
+async def list_scheduled_rules(
+    cursor: str | None = None, limit: int = 100
+) -> Dict[str, Any]:
     """List all scheduled rules from Panther with optional pagination
 
     Args:
@@ -270,7 +272,9 @@ async def get_scheduled_rule_by_id(rule_id: str) -> Dict[str, Any]:
         "permissions": all_perms(Permission.RULE_READ),
     }
 )
-async def list_simple_rules(cursor: str = None, limit: int = 100) -> Dict[str, Any]:
+async def list_simple_rules(
+    cursor: str | None = None, limit: int = 100
+) -> Dict[str, Any]:
     """List all simple rules from Panther with optional pagination
 
     Args:
@@ -372,7 +376,7 @@ async def get_simple_rule_by_id(rule_id: str) -> Dict[str, Any]:
         "permissions": all_perms(Permission.POLICY_READ),
     }
 )
-async def list_policies(cursor: str = None, limit: int = 100) -> Dict[str, Any]:
+async def list_policies(cursor: str | None = None, limit: int = 100) -> Dict[str, Any]:
     """List all policies from Panther with optional pagination
 
     Args:

--- a/src/mcp_panther/panther_mcp_core/tools/schemas.py
+++ b/src/mcp_panther/panther_mcp_core/tools/schemas.py
@@ -19,10 +19,10 @@ logger = logging.getLogger("mcp-panther")
     }
 )
 async def list_log_type_schemas(
-    contains: str = None,
-    is_archived: bool = None,
-    is_in_use: bool = None,
-    is_managed: bool = None,
+    contains: str | None = None,
+    is_archived: bool | None = None,
+    is_in_use: bool | None = None,
+    is_managed: bool | None = None,
 ) -> Dict[str, Any]:
     """List all available log type schemas in Panther. Schemas are transformation instructions that convert raw audit logs
     into structured data for the data lake and real-time Python rules.

--- a/src/mcp_panther/panther_mcp_core/tools/sources.py
+++ b/src/mcp_panther/panther_mcp_core/tools/sources.py
@@ -19,10 +19,10 @@ logger = logging.getLogger("mcp-panther")
     }
 )
 async def list_log_sources(
-    cursor: str = None,
-    log_types: List[str] = None,
-    is_healthy: bool = None,
-    integration_type: str = None,
+    cursor: str | None = None,
+    log_types: List[str] | None = None,
+    is_healthy: bool | None = None,
+    integration_type: str | None = None,
 ) -> Dict[str, Any]:
     """List log sources from Panther with optional filters.
 


### PR DESCRIPTION
Implicit optionals allowed a subtle error when calling the MCP server, where a pedantically correct LLM would literally pass None to all inputs, and Pydantic would reject it because the type annotation said it must be a str or not provided.

Only some models triggered this issue, and only sometimes at that (LLMs...).

Small type hint errors are much more significant in Pydantic-based systems, so a type checker like mypy/pyright/etc. is an extremely important tool to run during linting. I strongly recommend that Panther add type checking to the CI/CD process, as these kinds of type/pydantic errors can be pretty subtle and annoying.