### PR TITLE
Add SQL reserved word processing to data lake queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	ruff check $(dirs)
 
 docker: test
-	docker build -t mcp-panther .
+	docker build -t mcp-panther -t mcp-panther:latest -t mcp-panther:$(shell git rev-parse --abbrev-ref HEAD | sed 's|/|-|g') .
 
 # Create a virtual environment using uv (https://github.com/astral-sh/uv)
 # After creating, run: source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "starlette>=0.35.0",
     "fastmcp>=2.3.3",
+    "sqlparse>=0.4.4",
 ]
 
 [project.urls]

--- a/src/README.md
+++ b/src/README.md
@@ -21,6 +21,16 @@ This guide provides instructions for developers working on the MCP Panther proje
 
 The MCP Panther project is a server implementation for the Model Control Protocol (MCP) that provides integration with Panther Labs services.
 
+### Dependencies
+
+The project includes several key dependencies:
+
+- **FastMCP**: Core MCP server framework
+- **GQL**: GraphQL client for Panther API communication
+- **SQLParse**: SQL parsing library for reserved word processing in data lake queries
+- **Pydantic**: Data validation and serialization
+- **Uvicorn/Starlette**: ASGI server components
+
 ## Testing Changes
 
 ### Manual Testing
@@ -44,6 +54,8 @@ Or add the following to your MCP client configuration:
         "run",
         "--with",
         "fastmcp",
+        "--with",
+        "sqlparse",
         "--with",
         "aiohttp",
         "--with",

--- a/tests/panther_mcp_core/tools/test_data_lake.py
+++ b/tests/panther_mcp_core/tools/test_data_lake.py
@@ -2,14 +2,9 @@ import pytest
 from unittest.mock import patch
 
 from mcp_panther.panther_mcp_core.tools.data_lake import (
-    QueryStatus,
     _cancel_data_lake_query,
     execute_data_lake_query,
-<<<<<<< HEAD
-=======
-    list_data_lake_queries,
     wrap_reserved_words,
->>>>>>> fc27393 (Add SQL reserved word processing to data lake queries)
 )
 from tests.utils.helpers import patch_graphql_client
 
@@ -197,15 +192,13 @@ async def test_cancel_data_lake_query_success(mock_graphql_client):
     assert call_args["input"]["id"] == "query123"
 
 
-<<<<<<< HEAD
-=======
 @pytest.mark.asyncio
 @patch_graphql_client(DATA_LAKE_MODULE_PATH)
 async def test_cancel_data_lake_query_not_found(mock_graphql_client):
     """Test cancellation of a non-existent query."""
     mock_graphql_client.execute.side_effect = Exception("Query not found")
 
-    result = await cancel_data_lake_query("nonexistent")
+    result = await _cancel_data_lake_query("nonexistent")
 
     assert result["success"] is False
     assert "not found" in result["message"]
@@ -218,7 +211,7 @@ async def test_cancel_data_lake_query_cannot_cancel(mock_graphql_client):
     """Test cancellation of a query that cannot be cancelled."""
     mock_graphql_client.execute.side_effect = Exception("Query cannot be cancelled")
 
-    result = await cancel_data_lake_query("completed_query")
+    result = await _cancel_data_lake_query("completed_query")
 
     assert result["success"] is False
     assert "cannot be cancelled" in result["message"]
@@ -231,7 +224,7 @@ async def test_cancel_data_lake_query_permission_error(mock_graphql_client):
     """Test cancellation with permission error."""
     mock_graphql_client.execute.side_effect = Exception("Permission denied")
 
-    result = await cancel_data_lake_query("query123")
+    result = await _cancel_data_lake_query("query123")
 
     assert result["success"] is False
     assert "Permission denied" in result["message"]
@@ -244,7 +237,7 @@ async def test_cancel_data_lake_query_no_id_returned(mock_graphql_client):
     mock_response = {"cancelDataLakeQuery": {}}
     mock_graphql_client.execute.return_value = mock_response
 
-    result = await cancel_data_lake_query("query123")
+    result = await _cancel_data_lake_query("query123")
 
     assert result["success"] is False
     assert "No query ID returned" in result["message"]
@@ -258,22 +251,23 @@ def test_wrap_reserved_words_basic():
     test_cases = [
         {
             "input": "SELECT eventName as 'select', awsRegion as 'from' FROM aws_cloudtrail",
-            "expected_contains": ['"select"', '"from"'],
+            "expected": 'SELECT eventName as "select", awsRegion as "from" FROM aws_cloudtrail',
         },
         {
             "input": "SELECT 'table', 'column', 'index' FROM aws_cloudtrail",
-            "expected_contains": ['"table"', '"column"', '"index"'],
+            "expected": 'SELECT "table", "column", "index" FROM aws_cloudtrail',
         },
         {
             "input": "SELECT eventName FROM aws_cloudtrail WHERE 'where' > 100",
-            "expected_contains": ['"where"'],
+            "expected": 'SELECT eventName FROM aws_cloudtrail WHERE "where" > 100',
         },
     ]
 
     for case in test_cases:
         result = wrap_reserved_words(case["input"])
-        for expected in case["expected_contains"]:
-            assert expected in result, f"Expected '{expected}' in result: {result}"
+        assert result == case["expected"], (
+            f"Expected '{case['expected']}' but got '{result}'"
+        )
 
 
 def test_wrap_reserved_words_preserves_non_reserved():
@@ -295,13 +289,15 @@ def test_wrap_reserved_words_complex_query():
     ORDER BY 'select', 'from'
     """
 
+    expected = """
+    SELECT eventName as "select", awsRegion as "from"
+    FROM aws_cloudtrail 
+    WHERE p_event_time >= CURRENT_TIMESTAMP() - INTERVAL '1 DAY'
+    ORDER BY "select", "from"
+    """
+
     result = wrap_reserved_words(sql)
-    assert '"select"' in result
-    assert '"from"' in result
-    # Keywords used as SQL commands should not be quoted
-    assert "SELECT" in result
-    assert "FROM" in result
-    assert "WHERE" in result
+    assert result == expected
 
 
 def test_wrap_reserved_words_handles_errors():
@@ -323,8 +319,10 @@ async def test_execute_data_lake_query_with_reserved_words_processing(
     }
 
     # SQL with single-quoted reserved words that should be converted to double-quoted
-    sql = "SELECT eventName as 'select', awsRegion as 'from' FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(day, -30, CURRENT_TIMESTAMP()) LIMIT 10"
-    result = await execute_data_lake_query(sql)
+    input_sql = "SELECT eventName as 'select', awsRegion as 'from' FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(day, -30, CURRENT_TIMESTAMP()) LIMIT 10"
+    expected_processed_sql = 'SELECT eventName as "select", awsRegion as "from" FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(day, -30, CURRENT_TIMESTAMP()) LIMIT 10'
+
+    result = await execute_data_lake_query(input_sql)
 
     assert result["success"] is True
     assert result["query_id"] == MOCK_QUERY_ID
@@ -333,10 +331,5 @@ async def test_execute_data_lake_query_with_reserved_words_processing(
     call_args = mock_graphql_client.execute.call_args[1]["variable_values"]
     processed_sql = call_args["input"]["sql"]
 
-    # Should have converted single-quoted reserved words to double-quoted
-    assert '"select"' in processed_sql
-    assert '"from"' in processed_sql
-    # Should not contain single-quoted reserved words
-    assert "'select'" not in processed_sql
-    assert "'from'" not in processed_sql
->>>>>>> fc27393 (Add SQL reserved word processing to data lake queries)
+    # Assert the exact transformed SQL
+    assert processed_sql == expected_processed_sql

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "gql" },
     { name = "mcp", extra = ["cli"] },
+    { name = "sqlparse" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -429,6 +430,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.3.3" },
     { name = "gql", specifier = ">=3.5.2" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "sqlparse", specifier = ">=0.4.4" },
     { name = "starlette", specifier = ">=0.35.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]
@@ -802,6 +804,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add sqlparse dependency for SQL tokenization and reserved word processing
- Implement `wrap_reserved_words` function to automatically convert single-quoted reserved words to double-quoted identifiers in SQL queries
- Update data lake query execution to process SQL before validation to handle Snowflake reserved words correctly
- Add comprehensive tests for reserved word handling and edge cases
- Update developer documentation with new dependency information

## Changes Made
- **New dependency**: Added `sqlparse>=0.4.4` for SQL parsing capabilities
- **Reserved word processing**: Automatically converts single-quoted reserved words (e.g., `'select'`, `'from'`, `'table'`) to double-quoted identifiers (e.g., `"select"`, `"from"`, `"table"`)
- **Comprehensive testing**: Added unit tests covering basic reserved words, complex queries, error handling, and edge cases
- **Documentation updates**: Updated developer README and MCP client configuration examples

## Test Plan
### Manual Testing Steps
1. **Test reserved word conversion**:
   ```sql
   SELECT eventName as 'select', awsRegion as 'from' FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(day, -1, CURRENT_TIMESTAMP()) LIMIT 5
   ```
   - ✅ Should succeed and return results with columns named "select" and "from"

2. **Test multiple reserved words**:
   ```sql
   SELECT eventName as 'table', userIdentity:type as 'column', awsRegion as 'index' FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(hour, -2, CURRENT_TIMESTAMP()) LIMIT 3
   ```
   - ✅ Should succeed with columns "table", "column", "index"

3. **Test non-reserved word preservation**:
   ```sql
   SELECT eventName, sourceIPAddress as 'source_ip' FROM panther_logs.public.aws_cloudtrail WHERE p_event_time >= DATEADD(hour, -1, CURRENT_TIMESTAMP()) LIMIT 2
   ```
   - ❌ Should fail with syntax error because `'source_ip'` is not a reserved word and remains a string literal

4. **Test malformed SQL handling**:
   - Function should gracefully handle malformed SQL and return original query

### Automated Testing
- Run `make test` to execute unit tests
- Run `make integration-test` to validate MCP server functionality
- All existing tests continue to pass

## Technical Details
The implementation uses sqlparse to tokenize SQL queries and identify single-quoted string literals that match Snowflake reserved words. When found, these are converted to double-quoted identifiers, allowing them to be used as column aliases or table names without syntax errors.

🤖 Generated with [Claude Code](https://claude.ai/code)