### PR TITLE
Migrate alerts.py tools from GraphQL to REST API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Maintainers
-* @panther-labs/mcp-team
+* @panther-labs/mcp-team @tomasz-sq

--- a/.prd/resources/panther_open_api_v3_spec.yaml
+++ b/.prd/resources/panther_open_api_v3_spec.yaml
@@ -869,6 +869,27 @@ paths:
             description: the maximum results to return
             default: 100
             format: int64
+        - name: name-contains
+          in: query
+          description: Substring search by name (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Substring search by name (case-insensitive)
+        - name: created-by
+          in: query
+          description: Only include rules whose creator matches this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules whose creator matches this user ID or actor ID
+        - name: last-modified-by
+          in: query
+          description: Only include rules last modified by this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules last modified by this user ID or actor ID
       responses:
         '200':
           description: OK response.
@@ -1178,6 +1199,81 @@ paths:
             description: the maximum results to return
             default: 100
             format: int64
+        - name: compliance-status
+          in: query
+          description: Only include policies with this compliance status
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include policies with this compliance status
+            enum:
+              - PASS
+              - FAIL
+              - ERROR
+        - name: name-contains
+          in: query
+          description: Substring search by name (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Substring search by name (case-insensitive)
+        - name: state
+          in: query
+          description: Only include policies in the given state
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include policies in the given state
+            enum:
+              - enabled
+              - disabled
+        - name: resource-type
+          in: query
+          description: Only include policies which apply to one of the given resource types
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include policies which apply to one of the given resource types
+        - name: severity
+          in: query
+          description: Only include policies with one of the given severities
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - INFO
+                - LOW
+                - MEDIUM
+                - HIGH
+                - CRITICAL
+            description: Only include policies with one of the given severities
+        - name: tag
+          in: query
+          description: Only include policies with one of the given tags (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include policies with one of the given tags (case-insensitive)
+        - name: created-by
+          in: query
+          description: Only include policies whose creator matches this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include policies whose creator matches this user ID or actor ID
+        - name: last-modified-by
+          in: query
+          description: Only include policies last modified by this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include policies last modified by this user ID or actor ID
       responses:
         '200':
           description: OK response.
@@ -1699,6 +1795,70 @@ paths:
             description: the maximum results to return
             default: 100
             format: int64
+        - name: name-contains
+          in: query
+          description: Substring search by name (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Substring search by name (case-insensitive)
+        - name: state
+          in: query
+          description: Only include rules in the given state
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules in the given state
+            enum:
+              - enabled
+              - disabled
+        - name: log-type
+          in: query
+          description: Only include rules which apply to one of the given log types
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules which apply to one of the given log types
+        - name: severity
+          in: query
+          description: Only include rules with one of the given severities
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - INFO
+                - LOW
+                - MEDIUM
+                - HIGH
+                - CRITICAL
+            description: Only include rules with one of the given severities
+        - name: tag
+          in: query
+          description: Only include rules with one of the given tags (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules with one of the given tags (case-insensitive)
+        - name: created-by
+          in: query
+          description: Only include rules whose creator matches this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules whose creator matches this user ID or actor ID
+        - name: last-modified-by
+          in: query
+          description: Only include rules last modified by this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules last modified by this user ID or actor ID
       responses:
         '200':
           description: OK response.
@@ -1890,6 +2050,70 @@ paths:
             description: the maximum results to return
             default: 100
             format: int64
+        - name: name-contains
+          in: query
+          description: Substring search by name (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Substring search by name (case-insensitive)
+        - name: state
+          in: query
+          description: Only include rules in the given state
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules in the given state
+            enum:
+              - enabled
+              - disabled
+        - name: scheduled-query
+          in: query
+          description: Only include rules which apply to one of these scheduled queries
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules which apply to one of these scheduled queries
+        - name: severity
+          in: query
+          description: Only include rules with one of the given severities
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - INFO
+                - LOW
+                - MEDIUM
+                - HIGH
+                - CRITICAL
+            description: Only include rules with one of the given severities
+        - name: tag
+          in: query
+          description: Only include rules with one of the given tags (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules with one of the given tags (case-insensitive)
+        - name: created-by
+          in: query
+          description: Only include rules whose creator matches this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules whose creator matches this user ID or actor ID
+        - name: last-modified-by
+          in: query
+          description: Only include rules last modified by this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules last modified by this user ID or actor ID
       responses:
         '200':
           description: OK response.
@@ -2089,6 +2313,70 @@ paths:
             type: boolean
             description: determines if associated python for the generated rule is returned
             default: false
+        - name: name-contains
+          in: query
+          description: Substring search by name (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Substring search by name (case-insensitive)
+        - name: state
+          in: query
+          description: Only include rules in the given state
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules in the given state
+            enum:
+              - enabled
+              - disabled
+        - name: log-type
+          in: query
+          description: Only include rules which apply to one of the given log types
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules which apply to one of the given log types
+        - name: severity
+          in: query
+          description: Only include rules with one of the given severities
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - INFO
+                - LOW
+                - MEDIUM
+                - HIGH
+                - CRITICAL
+            description: Only include rules with one of the given severities
+        - name: tag
+          in: query
+          description: Only include rules with one of the given tags (case-insensitive)
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+            description: Only include rules with one of the given tags (case-insensitive)
+        - name: created-by
+          in: query
+          description: Only include rules whose creator matches this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules whose creator matches this user ID or actor ID
+        - name: last-modified-by
+          in: query
+          description: Only include rules last modified by this user ID or actor ID
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Only include rules last modified by this user ID or actor ID
       responses:
         '200':
           description: OK response.
@@ -2272,6 +2560,24 @@ paths:
       summary: List users
       operationId: user#list
       parameters:
+        - name: cursor
+          in: query
+          description: Pagination token
+          allowEmptyValue: true
+          schema:
+            type: string
+            description: Pagination token
+        - name: limit
+          in: query
+          description: Maximum number of results to return
+          allowEmptyValue: true
+          schema:
+            type: integer
+            description: Maximum number of results to return
+            default: 60
+            format: int64
+            minimum: 1
+            maximum: 60
         - name: contains
           in: query
           description: Search name and email fields in a case-insensitive fashion
@@ -2309,17 +2615,6 @@ paths:
           schema:
             type: boolean
             description: Include deactivated users
-        - name: sort-dir
-          in: query
-          description: The sort direction of the results
-          allowEmptyValue: true
-          schema:
-            type: string
-            description: The sort direction of the results
-            default: asc
-            enum:
-              - asc
-              - desc
         - name: status
           in: query
           description: Show only users with this Cognito status
@@ -3185,13 +3480,14 @@ components:
           description: The integration label (name)
         logStreamType:
           type: string
-          description: The log stream type
+          description: 'The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML'
           enum:
             - Auto
-            - CloudWatchLogs
             - JSON
             - JsonArray
             - Lines
+            - CloudWatchLogs
+            - XML
         logStreamTypeOptions:
           $ref: '#/components/schemas/HttpSourceAPI.LogStreamTypeOptions'
         logTypes:
@@ -3240,13 +3536,14 @@ components:
           description: The integration label (name)
         logStreamType:
           type: string
-          description: The log stream type
+          description: 'The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML'
           enum:
             - Auto
-            - CloudWatchLogs
             - JSON
             - JsonArray
             - Lines
+            - CloudWatchLogs
+            - XML
         logStreamTypeOptions:
           $ref: '#/components/schemas/HttpSourceAPI.LogStreamTypeOptions'
         logTypes:
@@ -3322,6 +3619,11 @@ components:
         managed:
           type: boolean
           description: Determines if the policy is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: Reports
@@ -3378,6 +3680,21 @@ components:
           description: The python body of the policy
         createdAt:
           type: string
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              enum:
+                - user
+                - api-token
+                - system
+            type:
+              type: string
+          description: The actor who created the rule
+        createdByExternal:
+          type: string
+          description: The text of the user-provided CreatedBy field when uploaded via CI/CD
         description:
           type: string
           description: The description of the policy
@@ -3395,6 +3712,11 @@ components:
         managed:
           type: boolean
           description: Determines if the policy is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: Reports
@@ -3803,6 +4125,11 @@ components:
         managed:
           type: boolean
           description: Determines if the rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: reports
@@ -3861,6 +4188,21 @@ components:
           description: The python body of the rule
         createdAt:
           type: string
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              enum:
+                - user
+                - api-token
+                - system
+            type:
+              type: string
+          description: The actor who created the rule
+        createdByExternal:
+          type: string
+          description: The text of the user-provided CreatedBy field when uploaded via CI/CD
         dedupPeriodMinutes:
           type: integer
           description: The amount of time in minutes for grouping alerts
@@ -3892,6 +4234,11 @@ components:
         managed:
           type: boolean
           description: Determines if the rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: reports
@@ -4061,6 +4408,11 @@ components:
         managed:
           type: boolean
           description: Determines if the scheduled rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: reports
@@ -4124,6 +4476,21 @@ components:
           description: The python body of the scheduled rule
         createdAt:
           type: string
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              enum:
+                - user
+                - api-token
+                - system
+            type:
+              type: string
+          description: The actor who created the rule
+        createdByExternal:
+          type: string
+          description: The text of the user-provided CreatedBy field when uploaded via CI/CD
         dedupPeriodMinutes:
           type: integer
           description: The amount of time in minutes for grouping alerts
@@ -4147,6 +4514,11 @@ components:
         managed:
           type: boolean
           description: Determines if the scheduled rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         reports:
           type: object
           description: reports
@@ -4341,6 +4713,11 @@ components:
         managed:
           type: boolean
           description: Determines if the simple rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         pythonBody:
           type: string
           description: The python body of the rule
@@ -4405,6 +4782,21 @@ components:
           description: The alert title represented in YAML
         createdAt:
           type: string
+        createdBy:
+          type: object
+          properties:
+            id:
+              type: string
+              enum:
+                - user
+                - api-token
+                - system
+            type:
+              type: string
+          description: The actor who created the rule
+        createdByExternal:
+          type: string
+          description: The text of the user-provided CreatedBy field when uploaded via CI/CD
         dedupPeriodMinutes:
           type: integer
           description: The amount of time in minutes for grouping alerts
@@ -4445,6 +4837,11 @@ components:
         managed:
           type: boolean
           description: Determines if the simple rule is managed by panther
+        outputIDs:
+          type: array
+          items:
+            type: string
+          description: Destination IDs that override default alert routing based on severity
         pythonBody:
           type: string
           description: The python body of the rule

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -218,19 +218,11 @@ async def get_alert_by_id(alert_id: str) -> Dict[str, Any]:
     """
     logger.info(f"Fetching alert details for ID: {alert_id}")
     try:
-        client = await _create_panther_client()
-
-        # Prepare input variables
-        variables = {"id": alert_id}
-
-        # Execute the query asynchronously
-        async with await get_rest_client() as client:
+        # Execute the REST API call
+        async with get_rest_client() as client:
             alert_data, status = await client.get(
                 f"/alerts/{alert_id}", expected_codes=[200, 400, 404]
             )
-
-        # Get alert data
-        alert_data = result.get("alert", {})
 
         if status == 404:
             logger.warning(f"No alert found with ID: {alert_id}")
@@ -360,7 +352,7 @@ async def update_alert_status(alert_ids: List[str], status: str) -> Dict[str, An
         # Execute the REST API call
         async with get_rest_client() as client:
             result, status_code = await client.patch(
-                "/alerts", body=body, expected_codes=[204, 400, 404]
+                "/alerts", json_data=body, expected_codes=[204, 400, 404]
             )
 
         if status_code == 404:
@@ -423,7 +415,7 @@ async def add_alert_comment(alert_id: str, comment: str) -> Dict[str, Any]:
         # Execute the REST API call
         async with get_rest_client() as client:
             comment_data, status = await client.post(
-                "/alert-comments", body=body, expected_codes=[200, 400, 404]
+                "/alert-comments", json_data=body, expected_codes=[200, 400, 404]
             )
 
         if status == 404:
@@ -489,7 +481,7 @@ async def update_alert_assignee_by_id(
         # Execute the REST API call
         async with get_rest_client() as client:
             result, status = await client.patch(
-                "/alerts", body=body, expected_codes=[204, 400, 404]
+                "/alerts", json_data=body, expected_codes=[204, 400, 404]
             )
 
         if status == 404:

--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -6,19 +6,10 @@ import logging
 from typing import Any, Dict, List
 
 from ..client import (
-    _create_panther_client,
-    _execute_query,
     _get_today_date_range,
     get_rest_client,
 )
 from ..permissions import Permission, all_perms
-from ..queries import (
-    ADD_ALERT_COMMENT_MUTATION,
-    GET_ALERT_BY_ID_QUERY,
-    GET_TODAYS_ALERTS_QUERY,
-    UPDATE_ALERT_STATUS_MUTATION,
-    UPDATE_ALERTS_ASSIGNEE_BY_ID_MUTATION,
-)
 from .registry import mcp_tool
 
 logger = logging.getLogger("mcp-panther")
@@ -74,8 +65,6 @@ async def list_alerts(
     logger.info("Fetching alerts from Panther")
 
     try:
-        client = await _create_panther_client()
-
         # Validate page size
         if page_size < 1:
             raise ValueError("page_size must be greater than 0")
@@ -109,23 +98,19 @@ async def list_alerts(
                     f"Valid subtypes are: {allowed_subtypes}"
                 )
 
-        # Prepare base input variables
-        variables = {
-            "input": {
-                "pageSize": page_size,
-                "sortBy": "createdAt",
-                "sortDir": "descending",
-                "type": alert_type,
-            }
+        # Prepare query parameters
+        params = {
+            "type": alert_type,
+            "limit": page_size,
+            "sort-dir": "desc",
         }
 
-        # Handle the required filter: either detectionId OR date range
+        # Handle the required filter: either detection-id OR date range
         if detection_id:
-            variables["input"]["detectionId"] = detection_id
+            params["detection-id"] = detection_id
             logger.info(f"Filtering by detection ID: {detection_id}")
         else:
             # If no detection_id, we must have a date range
-            # TODO(jn): Add support for relative date ranges
             if not start_date or not end_date:
                 start_date, end_date = _get_today_date_range()
                 logger.info(
@@ -134,72 +119,75 @@ async def list_alerts(
             else:
                 logger.info(f"Using provided date range: {start_date} to {end_date}")
 
-            variables["input"]["createdAtAfter"] = start_date
-            variables["input"]["createdAtBefore"] = end_date
+            params["created-after"] = start_date
+            params["created-before"] = end_date
 
         # Add optional filters
         if cursor:
             if not isinstance(cursor, str):
                 raise ValueError(
-                    "Cursor must be a string value from previous response's endCursor"
+                    "Cursor must be a string value from previous response's next"
                 )
-            variables["input"]["cursor"] = cursor
+            params["cursor"] = cursor
             logger.info(f"Using cursor for pagination: {cursor}")
 
         if severities:
-            variables["input"]["severities"] = severities
+            params["severity"] = severities
             logger.info(f"Filtering by severities: {severities}")
 
         if statuses:
-            variables["input"]["statuses"] = statuses
+            params["status"] = statuses
             logger.info(f"Filtering by statuses: {statuses}")
 
         if event_count_max is not None:
-            variables["input"]["eventCountMax"] = event_count_max
+            params["event-count-max"] = event_count_max
             logger.info(f"Filtering by max event count: {event_count_max}")
 
         if event_count_min is not None:
-            variables["input"]["eventCountMin"] = event_count_min
+            params["event-count-min"] = event_count_min
             logger.info(f"Filtering by min event count: {event_count_min}")
 
         if log_sources:
-            variables["input"]["logSources"] = log_sources
+            params["log-source"] = log_sources
             logger.info(f"Filtering by log sources: {log_sources}")
 
         if log_types:
-            variables["input"]["logTypes"] = log_types
+            params["log-type"] = log_types
             logger.info(f"Filtering by log types: {log_types}")
 
         if name_contains:
-            variables["input"]["nameContains"] = name_contains
+            params["name-contains"] = name_contains
             logger.info(f"Filtering by name contains: {name_contains}")
 
         if resource_types:
-            variables["input"]["resourceTypes"] = resource_types
+            params["resource-type"] = resource_types
             logger.info(f"Filtering by resource types: {resource_types}")
 
         if subtypes:
-            variables["input"]["subtypes"] = subtypes
+            params["sub-type"] = subtypes
             logger.info(f"Filtering by subtypes: {subtypes}")
 
-        logger.debug(f"Query variables: {variables}")
+        logger.debug(f"Query parameters: {params}")
 
-        # Execute the query asynchronously
-        async with client as session:
-            result = await session.execute(
-                GET_TODAYS_ALERTS_QUERY, variable_values=variables
+        # Execute the REST API call
+        async with get_rest_client() as client:
+            result, status = await client.get(
+                "/alerts", params=params, expected_codes=[200, 400]
             )
 
+        if status == 400:
+            logger.error("Bad request when fetching alerts")
+            return {
+                "success": False,
+                "message": "Bad request when fetching alerts",
+            }
+
         # Log the raw result for debugging
-        logger.debug(f"Raw query result: {result}")
+        logger.debug(f"Raw API result: {result}")
 
         # Process results
-        alerts_data = result.get("alerts", {})
-        alert_edges = alerts_data.get("edges", [])
-        page_info = alerts_data.get("pageInfo", {})
-
-        # Extract alerts from edges
-        alerts = [edge["node"] for edge in alert_edges]
+        alerts = result.get("results", [])
+        next_cursor = result.get("next")
 
         logger.info(f"Successfully retrieved {len(alerts)} alerts")
 
@@ -208,10 +196,10 @@ async def list_alerts(
             "success": True,
             "alerts": alerts,
             "total_alerts": len(alerts),
-            "has_next_page": page_info.get("hasNextPage", False),
-            "has_previous_page": page_info.get("hasPreviousPage", False),
-            "end_cursor": page_info.get("endCursor"),
-            "start_cursor": page_info.get("startCursor"),
+            "has_next_page": next_cursor is not None,
+            "has_previous_page": cursor is not None,
+            "end_cursor": next_cursor,
+            "start_cursor": cursor,
         }
     except Exception as e:
         logger.error(f"Failed to fetch alerts: {str(e)}")
@@ -224,24 +212,36 @@ async def list_alerts(
     }
 )
 async def get_alert_by_id(alert_id: str) -> Dict[str, Any]:
-    """Get detailed information about a specific Panther alert by ID"""
+    """Get detailed information about a specific Panther alert by ID
+
+    TODO: v2.0 - Rename to get_alert() since by_id suffix is redundant
+    """
     logger.info(f"Fetching alert details for ID: {alert_id}")
     try:
+        client = await _create_panther_client()
+
         # Prepare input variables
         variables = {"id": alert_id}
 
         # Execute the query asynchronously
-        async with await _create_panther_client() as session:
-            result = await session.execute(
-                GET_ALERT_BY_ID_QUERY, variable_values=variables
+        async with await get_rest_client() as client:
+            alert_data, status = await client.get(
+                f"/alerts/{alert_id}", expected_codes=[200, 400, 404]
             )
 
         # Get alert data
         alert_data = result.get("alert", {})
 
-        if not alert_data:
+        if status == 404:
             logger.warning(f"No alert found with ID: {alert_id}")
             return {"success": False, "message": f"No alert found with ID: {alert_id}"}
+
+        if status == 400:
+            logger.error(f"Bad request when fetching alert ID: {alert_id}")
+            return {
+                "success": False,
+                "message": f"Bad request when fetching alert ID: {alert_id}",
+            }
 
         logger.info(f"Successfully retrieved alert details for ID: {alert_id}")
 
@@ -333,10 +333,7 @@ async def update_alert_status(alert_ids: List[str], status: str) -> Dict[str, An
     Returns:
         Dict containing:
         - success: Boolean indicating if the update was successful
-        - alerts: List of updated alerts if successful, each containing:
-            - id: The alert ID
-            - status: The new status
-            - updatedAt: Timestamp of the update
+        - alerts: List of updated alert IDs if successful
         - message: Error message if unsuccessful
 
     Example:
@@ -354,29 +351,37 @@ async def update_alert_status(alert_ids: List[str], status: str) -> Dict[str, An
         if status not in valid_statuses:
             raise ValueError(f"Status must be one of {valid_statuses}")
 
-        # Prepare variables
-        variables = {
-            "input": {
-                "ids": alert_ids,
-                "status": status,
-            }
+        # Prepare request body
+        body = {
+            "ids": alert_ids,
+            "status": status,
         }
 
-        # Execute mutation
-        result = await _execute_query(UPDATE_ALERT_STATUS_MUTATION, variables)
+        # Execute the REST API call
+        async with get_rest_client() as client:
+            result, status_code = await client.patch(
+                "/alerts", body=body, expected_codes=[204, 400, 404]
+            )
 
-        if not result or "updateAlertStatusById" not in result:
-            raise Exception("Failed to update alert status")
+        if status_code == 404:
+            logger.error(f"One or more alerts not found: {alert_ids}")
+            return {
+                "success": False,
+                "message": f"One or more alerts not found: {alert_ids}",
+            }
 
-        alerts_data = result["updateAlertStatusById"]["alerts"]
+        if status_code == 400:
+            logger.error(f"Bad request when updating alert status: {alert_ids}")
+            return {
+                "success": False,
+                "message": f"Bad request when updating alert status: {alert_ids}",
+            }
 
-        logger.info(
-            f"Successfully updated {len(alerts_data)} alerts to status {status}"
-        )
+        logger.info(f"Successfully updated {len(alert_ids)} alerts to status {status}")
 
         return {
             "success": True,
-            "alerts": alerts_data,
+            "alerts": alert_ids,  # Return the IDs that were updated
         }
 
     except Exception as e:
@@ -408,21 +413,32 @@ async def add_alert_comment(alert_id: str, comment: str) -> Dict[str, Any]:
     logger.info(f"Adding comment to alert {alert_id}")
 
     try:
-        # Prepare variables
-        variables = {
-            "input": {
-                "alertId": alert_id,
-                "body": comment,
-            }
+        # Prepare request body
+        body = {
+            "alertId": alert_id,
+            "body": comment,
+            "format": "PLAIN_TEXT",  # Default format
         }
 
-        # Execute mutation
-        result = await _execute_query(ADD_ALERT_COMMENT_MUTATION, variables)
+        # Execute the REST API call
+        async with get_rest_client() as client:
+            comment_data, status = await client.post(
+                "/alert-comments", body=body, expected_codes=[200, 400, 404]
+            )
 
-        if not result or "createAlertComment" not in result:
-            raise Exception("Failed to add alert comment")
+        if status == 404:
+            logger.error(f"Alert not found: {alert_id}")
+            return {
+                "success": False,
+                "message": f"Alert not found: {alert_id}",
+            }
 
-        comment_data = result["createAlertComment"]["comment"]
+        if status == 400:
+            logger.error(f"Bad request when adding comment to alert {alert_id}")
+            return {
+                "success": False,
+                "message": f"Bad request when adding comment to alert {alert_id}",
+            }
 
         logger.info(f"Successfully added comment to alert {alert_id}")
 
@@ -449,6 +465,8 @@ async def update_alert_assignee_by_id(
 ) -> Dict[str, Any]:
     """Update the assignee of one or more alerts through the assignee's ID.
 
+    TODO: v2.0 - Rename to update_alert_assignee() since by_id suffix is redundant
+
     Args:
         alert_ids: List of alert IDs to update
         assignee_id: The ID of the user to assign the alerts to
@@ -456,33 +474,43 @@ async def update_alert_assignee_by_id(
     Returns:
         Dict containing:
         - success: Boolean indicating if the update was successful
-        - alerts: List of updated alerts if successful
+        - alerts: List of updated alert IDs if successful
         - message: Error message if unsuccessful
     """
     logger.info(f"Updating assignee for alerts {alert_ids} to user {assignee_id}")
 
     try:
-        # Prepare variables
-        variables = {
-            "input": {
-                "ids": alert_ids,
-                "assigneeId": assignee_id,
-            }
+        # Prepare request body
+        body = {
+            "ids": alert_ids,
+            "assignee": assignee_id,
         }
 
-        # Execute mutation
-        result = await _execute_query(UPDATE_ALERTS_ASSIGNEE_BY_ID_MUTATION, variables)
+        # Execute the REST API call
+        async with get_rest_client() as client:
+            result, status = await client.patch(
+                "/alerts", body=body, expected_codes=[204, 400, 404]
+            )
 
-        if not result or "updateAlertsAssigneeById" not in result:
-            raise Exception("Failed to update alert assignee")
+        if status == 404:
+            logger.error(f"One or more alerts not found: {alert_ids}")
+            return {
+                "success": False,
+                "message": f"One or more alerts not found: {alert_ids}",
+            }
 
-        alerts_data = result["updateAlertsAssigneeById"]["alerts"]
+        if status == 400:
+            logger.error(f"Bad request when updating alert assignee: {alert_ids}")
+            return {
+                "success": False,
+                "message": f"Bad request when updating alert assignee: {alert_ids}",
+            }
 
         logger.info(f"Successfully updated assignee for alerts {alert_ids}")
 
         return {
             "success": True,
-            "alerts": alerts_data,
+            "alerts": alert_ids,  # Return the IDs that were updated
         }
 
     except Exception as e:

--- a/tests/panther_mcp_core/tools/test_alerts.py
+++ b/tests/panther_mcp_core/tools/test_alerts.py
@@ -229,8 +229,8 @@ async def test_update_alert_status_success(mock_rest_client):
     # Verify patch was called with correct parameters
     mock_rest_client.patch.assert_called_once()
     call_args = mock_rest_client.patch.call_args
-    assert call_args[1]["body"]["ids"] == [MOCK_ALERT["id"]]
-    assert call_args[1]["body"]["status"] == "TRIAGED"
+    assert call_args[1]["json_data"]["ids"] == [MOCK_ALERT["id"]]
+    assert call_args[1]["json_data"]["status"] == "TRIAGED"
 
 
 @pytest.mark.asyncio

--- a/tests/panther_mcp_core/tools/test_data_lake.py
+++ b/tests/panther_mcp_core/tools/test_data_lake.py
@@ -333,7 +333,7 @@ async def test_execute_data_lake_query_with_reserved_words_processing(
             "end_cursor": None,
             "message": "Query executed successfully",
         }
-        
+
         result = await execute_data_lake_query(input_sql)
 
     # Verify the function returns success


### PR DESCRIPTION
## Summary
- Migrated all alert tools from GraphQL to REST API endpoints
- Updated parameter naming from `body` to `json_data` for consistency
- Fixed test cases to match new REST API structure
- All tools tested and working correctly

## Test plan
- [x] All alert tools tested successfully through MCP server
- [x] Unit tests updated and passing
- [x] Integration testing completed

🤖 Generated with [Claude Code](https://claude.ai/code)