### PR TITLE
chore!: drop support for --compat-mode flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ fmt:
 lint:
 	ruff check $(dirs)
 
-docker: test
+docker:
 	docker build -t mcp-panther -t mcp-panther:latest -t mcp-panther:$(shell git rev-parse --abbrev-ref HEAD | sed 's|/|-|g') .
 
 # Create a virtual environment using uv (https://github.com/astral-sh/uv)

--- a/README.md
+++ b/README.md
@@ -240,10 +240,8 @@ Use with [Goose CLI](https://block.github.io/goose/docs/getting-started/installa
 
 ```bash
 # Start Goose with the MCP server
-goose session --with-extension "uvx mcp-panther --compat-mode"
+goose session --with-extension "uvx mcp-panther"
 ```
-
-The `--compat-mode` flag enables compatibility mode for broader MCP client support, especially for clients using older MCP versions that may not support all the latest features.
 
 ### Goose Desktop
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-panther"
-version = "2.0.0"
+version = "2.0.0rc1"
 description = "Panther Labs MCP Server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-panther"
-version = "1.1.0"
+version = "2.0.0"
 description = "Panther Labs MCP Server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -24,14 +24,11 @@ classifiers = [
 ]
 keywords = ["security", "ai", "mcp", "mcp-server", "panther"]
 dependencies = [
-    "aiohttp>=3.11.14",
-    "gql>=3.5.2",
-    "mcp[cli]>=1.6.0",
-    "click>=8.1.0",
-    "uvicorn>=0.24.0",
-    "starlette>=0.35.0",
-    "fastmcp>=2.3.3",
-    "sqlparse>=0.4.4",
+    "aiohttp>=3.11.14,<4.0.0",
+    "gql>=3.5.2,<4.0.0",
+    "click>=8.1.0,<9.0.0",
+    "fastmcp>=2.3.3,<3.0.0",
+    "sqlparse>=0.4.4,<1.0.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-panther"
-version = "2.0.0rc1"
+version = "2.0.0"
 description = "Panther Labs MCP Server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_panther/panther_mcp_core/prompts/registry.py
+++ b/src/mcp_panther/panther_mcp_core/prompts/registry.py
@@ -8,8 +8,6 @@ import logging
 from functools import wraps
 from typing import Callable, Optional, Set
 
-from ..utils import USE_LEGACY_MCP
-
 logger = logging.getLogger("mcp-panther")
 
 # Registry to store all prompt functions
@@ -88,17 +86,11 @@ def register_all_prompts(mcp_instance) -> None:
         metadata = getattr(prompt, "_mcp_prompt_metadata", {})
 
         # Create prompt decorator with metadata
-        if USE_LEGACY_MCP:
-            prompt_decorator = mcp_instance.prompt(
-                name=metadata.get("name"),
-                description=metadata.get("description"),
-            )
-        else:
-            prompt_decorator = mcp_instance.prompt(
-                name=metadata.get("name"),
-                description=metadata.get("description"),
-                tags=metadata.get("tags"),
-            )
+        prompt_decorator = mcp_instance.prompt(
+            name=metadata.get("name"),
+            description=metadata.get("description"),
+            tags=metadata.get("tags"),
+        )
 
         # Register the prompt
         prompt_decorator(prompt)

--- a/src/mcp_panther/panther_mcp_core/resources/registry.py
+++ b/src/mcp_panther/panther_mcp_core/resources/registry.py
@@ -10,8 +10,6 @@ import logging
 from functools import wraps
 from typing import Callable, Dict, Optional, Set
 
-from ..utils import USE_LEGACY_MCP
-
 logger = logging.getLogger("mcp-panther")
 
 # Registry to store all decorated resources
@@ -80,21 +78,13 @@ def register_all_resources(mcp_instance) -> None:
         metadata = getattr(resource_func, "_mcp_resource_metadata", {})
 
         # Create resource decorator with metadata
-        if USE_LEGACY_MCP:
-            resource_decorator = mcp_instance.resource(
-                uri,
-                name=metadata.get("name"),
-                description=metadata.get("description"),
-                mime_type=metadata.get("mime_type"),
-            )
-        else:
-            resource_decorator = mcp_instance.resource(
-                uri=metadata["uri"],
-                name=metadata.get("name"),
-                description=metadata.get("description"),
-                mime_type=metadata.get("mime_type"),
-                tags=metadata.get("tags"),
-            )
+        resource_decorator = mcp_instance.resource(
+            uri=metadata["uri"],
+            name=metadata.get("name"),
+            description=metadata.get("description"),
+            mime_type=metadata.get("mime_type"),
+            tags=metadata.get("tags"),
+        )
 
         # Register the resource
         resource_decorator(resource_func)

--- a/src/mcp_panther/panther_mcp_core/utils.py
+++ b/src/mcp_panther/panther_mcp_core/utils.py
@@ -1,8 +1,4 @@
-import os
-import sys
 from typing import Union
-
-COMPATIBILITY_MODE_FLAG = "--compat-mode"
 
 
 def parse_bool(value: Union[str, bool, None]) -> bool:
@@ -12,9 +8,3 @@ def parse_bool(value: Union[str, bool, None]) -> bool:
     if isinstance(value, bool):
         return value
     return value.lower() in ("true", "1", "yes", "on", "enabled")
-
-
-USE_LEGACY_MCP = (
-    bool(parse_bool(os.getenv("USE_LEGACY_MCP", "false")))
-    or COMPATIBILITY_MODE_FLAG in sys.argv
-)

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -57,23 +57,16 @@ try:
     from panther_mcp_core.prompts.registry import register_all_prompts
     from panther_mcp_core.resources.registry import register_all_resources
     from panther_mcp_core.tools.registry import register_all_tools
-    from panther_mcp_core.utils import COMPATIBILITY_MODE_FLAG, USE_LEGACY_MCP
 except ImportError:
     from .panther_mcp_core.prompts.registry import register_all_prompts
     from .panther_mcp_core.resources.registry import register_all_resources
     from .panther_mcp_core.tools.registry import register_all_tools
-    from .panther_mcp_core.utils import COMPATIBILITY_MODE_FLAG, USE_LEGACY_MCP
 
 # Server dependencies
 deps = [
     "gql[aiohttp]",
     "aiohttp",
 ]
-
-if USE_LEGACY_MCP:
-    from mcp.server.fastmcp import FastMCP
-else:
-    from fastmcp import FastMCP
 
 # Create the MCP server
 mcp = FastMCP(MCP_SERVER_NAME, dependencies=deps)
@@ -105,12 +98,6 @@ def handle_signals():
     help="Transport type (stdio or streamable-http)",
 )
 @click.option(
-    COMPATIBILITY_MODE_FLAG,
-    is_flag=True,
-    default=USE_LEGACY_MCP,
-    help="Enable compatibility mode for broader MCP client support",
-)
-@click.option(
     "--port",
     default=int(os.environ.get("MCP_PORT", default="3000")),
     help="Port to use for streamable HTTP transport",
@@ -126,7 +113,7 @@ def handle_signals():
     default=os.environ.get("MCP_LOG_FILE"),
     help="Write logs to this file instead of stderr",
 )
-def main(transport: str, compat_mode: bool, port: int, host: str, log_file: str | None):
+def main(transport: str, port: int, host: str, log_file: str | None):
     """Run the Panther MCP server with the specified transport"""
     # Set up signal handling
     handle_signals()
@@ -134,9 +121,6 @@ def main(transport: str, compat_mode: bool, port: int, host: str, log_file: str 
     # Reconfigure logging if a log file is provided
     if log_file:
         configure_logging(log_file, force=True)
-
-    if USE_LEGACY_MCP:
-        logger.info("using compatability mode")
 
     major = sys.version_info.major
     minor = sys.version_info.minor

--- a/uv.lock
+++ b/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "mcp-panther"
-version = "2.0.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -393,25 +393,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/d5/22e36c95c83c80eb47c83f231095419cf57cf5cca5416f1c960032074c78/mcp-1.9.0-py3-none-any.whl", hash = "sha256:9dfb89c8c56f742da10a5910a1f64b0d2ac2c3ed2bd572ddb1cfab7f35957178", size = 125082 },
 ]
 
-[package.optional-dependencies]
-cli = [
-    { name = "python-dotenv" },
-    { name = "typer" },
-]
-
 [[package]]
 name = "mcp-panther"
-version = "1.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
     { name = "fastmcp" },
     { name = "gql" },
-    { name = "mcp", extra = ["cli"] },
     { name = "sqlparse" },
-    { name = "starlette" },
-    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -425,14 +416,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.11.14" },
-    { name = "click", specifier = ">=8.1.0" },
-    { name = "fastmcp", specifier = ">=2.3.3" },
-    { name = "gql", specifier = ">=3.5.2" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
-    { name = "sqlparse", specifier = ">=0.4.4" },
-    { name = "starlette", specifier = ">=0.35.0" },
-    { name = "uvicorn", specifier = ">=0.24.0" },
+    { name = "aiohttp", specifier = ">=3.11.14,<4.0.0" },
+    { name = "click", specifier = ">=8.1.0,<9.0.0" },
+    { name = "fastmcp", specifier = ">=2.3.3,<3.0.0" },
+    { name = "gql", specifier = ">=3.5.2,<4.0.0" },
+    { name = "sqlparse", specifier = ">=0.4.4,<1.0.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "mcp-panther"
-version = "2.0.0rc1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Remove deprecated `--compat-mode` flag** and associated legacy MCP support code
- **Simplify dependency management** by removing unused dependencies and adding version constraints
- **Streamline codebase** by eliminating compatibility layer for older MCP clients

## Changes

### Breaking Changes ⚠️

- **Removed `--compat-mode` CLI flag**: This flag provided compatibility with older MCP clients but is no longer needed
- **Version bump to 2.0.0**: Reflects the breaking nature of removing the compatibility mode
- **Removed legacy MCP dependency**: The `mcp[cli]` dependency and related imports have been removed in favor of the modern `fastmcp` library

### Code Cleanup

- **Simplified registration logic**: Removed conditional logic in prompt and resource registries that handled legacy vs. modern MCP clients
- **Removed unused utilities**: Eliminated `USE_LEGACY_MCP` flag and related compatibility checking code
- **Streamlined dependencies**: Removed `uvicorn`, `starlette`, and `mcp[cli]` dependencies that are no longer needed

### Documentation Updates

- **Updated Goose CLI instructions**: Removed reference to `--compat-mode` flag in README
- **Removed compatibility mode explanation**: Cleaned up documentation that referenced the deprecated flag

### Build Changes

- **Simplified Docker build**: Removed test requirement from Docker build process in Makefile
- **Updated dependency constraints**: Added upper bound version constraints to prevent breaking changes from major version bumps