### PR TITLE
Clearing the default filterings for api calls

### DIFF
--- a/src/mcp_panther/panther_mcp_core/tools/alerts.py
+++ b/src/mcp_panther/panther_mcp_core/tools/alerts.py
@@ -55,7 +55,7 @@ async def list_alerts(
             description="Optional list of severities to filter by",
             examples=[["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]],
         ),
-    ] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+    ] = [],
     statuses: Annotated[
         list[str],
         BeforeValidator(_validate_statuses),
@@ -67,7 +67,7 @@ async def list_alerts(
                 ["OPEN", "TRIAGED"],
             ],
         ),
-    ] = ["OPEN", "TRIAGED", "RESOLVED", "CLOSED"],
+    ] = [],
     cursor: Annotated[
         str | None,
         Field(
@@ -138,7 +138,7 @@ async def list_alerts(
                 ],  # When alert_type=DETECTION_ERROR
             ],
         ),
-    ] = ["RULE", "SCHEDULED_RULE"],
+    ] = [],
     alert_type: Annotated[
         str,
         BeforeValidator(_validate_alert_api_types),

--- a/src/mcp_panther/panther_mcp_core/tools/detections.py
+++ b/src/mcp_panther/panther_mcp_core/tools/detections.py
@@ -158,7 +158,7 @@ async def list_detections(
         Field(
             description="Filter by state - 'enabled' or 'disabled'", default="enabled"
         ),
-    ] = "enabled",
+    ] = "",
     severity: Annotated[
         list[str],
         Field(
@@ -168,7 +168,7 @@ async def list_detections(
                 ["INFO", "LOW"],
             ],
         ),
-    ] = ["MEDIUM", "HIGH", "CRITICAL"],
+    ] = [],
     tag: Annotated[
         list[str],
         Field(

--- a/tests/panther_mcp_core/tools/test_alerts.py
+++ b/tests/panther_mcp_core/tools/test_alerts.py
@@ -97,7 +97,18 @@ async def test_list_alerts_with_default_params(mock_rest_client):
     assert "severity" not in params
     assert "status" not in params 
     assert "subtypes" not in params
+    assert "log_sources" not in params
+    assert "log_types" not in params
+    assert "resource_types" not in params
+    assert "name_contains" not in params
+    assert "event_count_min" not in params
+    assert "event_count_max" not in params
+    assert "detection_id" not in params
+    assert "assignee" not in params
+    assert params["limit"] == 25
     assert params["type"] == "ALERT"
+    assert params["sort-dir"] == "desc"
+
 
 
 

--- a/tests/panther_mcp_core/tools/test_alerts.py
+++ b/tests/panther_mcp_core/tools/test_alerts.py
@@ -85,6 +85,24 @@ async def test_list_alerts_with_invalid_page_size(mock_rest_client):
 
 @pytest.mark.asyncio
 @patch_rest_client(ALERTS_MODULE_PATH)
+async def test_list_alerts_with_default_params(mock_rest_client):
+    """Test that default parameters are correctly set."""
+    mock_rest_client.get.return_value = (MOCK_ALERTS_RESPONSE, 200)
+    
+    await list_alerts()
+    
+    mock_rest_client.get.assert_called_once()
+    args, kwargs = mock_rest_client.get.call_args
+    params = kwargs["params"]
+    assert "severity" not in params
+    assert "status" not in params 
+    assert "subtypes" not in params
+    assert params["type"] == "ALERT"
+
+
+
+@pytest.mark.asyncio
+@patch_rest_client(ALERTS_MODULE_PATH)
 async def test_list_alerts_with_filters(mock_rest_client):
     """Test listing alerts with various filters."""
     mock_rest_client.get.return_value = (MOCK_ALERTS_RESPONSE, 200)

--- a/tests/panther_mcp_core/tools/test_detections.py
+++ b/tests/panther_mcp_core/tools/test_detections.py
@@ -763,6 +763,12 @@ async def test_list_detections_with_default_params(mock_rest_client):
     params = kwargs["params"]
     assert "severity" not in params
     assert "state" not in params 
+    assert "tag" not in params
+    assert "log-type" not in params
+    assert "created_by" not in params
+    assert "last_modified_by" not in params
+    assert params["limit"] == 100
+    assert "name_contains" not in params
     
 
 @pytest.mark.asyncio

--- a/tests/panther_mcp_core/tools/test_detections.py
+++ b/tests/panther_mcp_core/tools/test_detections.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import pytest
 
 from mcp_panther.panther_mcp_core.tools.detections import (
@@ -748,6 +749,21 @@ async def test_list_detections_with_detection_type_specific_params():
         "compliance_status parameter is only valid for 'policies'" in result["message"]
     )
 
+
+@pytest.mark.asyncio
+@patch_rest_client(RULES_MODULE_PATH)
+async def test_list_detections_with_default_params(mock_rest_client):
+    """Test that default parameters are correctly set."""
+    mock_rest_client.get.return_value = (MOCK_RULES_RESPONSE, 200)
+    
+    await list_detections(["rules"])
+    
+    mock_rest_client.get.assert_called_once()
+    args, kwargs = mock_rest_client.get.call_args
+    params = kwargs["params"]
+    assert "severity" not in params
+    assert "state" not in params 
+    
 
 @pytest.mark.asyncio
 @patch_rest_client(RULES_MODULE_PATH)


### PR DESCRIPTION
### Description
- Issue: When using the MCP tool to make API calls like `list_detections` without additional parameters, the results did not match what users see in the console. This was because the MCP tool’s default API calls included implicit filters (e.g., severity and state), which differs from the default parameters described in our documentation. This discrepancy could lead to confusion.
- Fix: This PR removes the default filters from MCP API calls such as list_detections and list_alerts, ensuring the results now align with the [current documentation](https://docs.panther.com/panther-developer-workflows/api/rest).

### References

[Jira ticket](https://panther-labs.atlassian.net/browse/EPD-3848?atlOrigin=eyJpIjoiNGVjZjIwNDRhZTY2NGRiYmI0NzAwYTNkOTBiM2NlY2EiLCJwIjoiaiJ9)

### Checklist

- [x] Added unit tests
- [x] Tested list_detections (Matches 123 enabled rule+simple rule in console)
<img width="283" height="618" alt="Screenshot 2025-09-15 at 1 59 05 PM" src="https://github.com/user-attachments/assets/9cc13764-f788-4cc4-a1f4-f30d10d442bc" />
<img width="281" height="302" alt="Screenshot 2025-09-15 at 2 02 08 PM" src="https://github.com/user-attachments/assets/9df95494-7334-49c4-b06a-361b704a8386" />

- [x] Tested list_alerts (INFO alerts are coming through as well)
<img width="265" height="588" alt="Screenshot 2025-09-15 at 2 18 46 PM" src="https://github.com/user-attachments/assets/dcb61d82-643d-4780-9e51-deb36d2a2729" />
<img width="293" height="484" alt="Screenshot 2025-09-15 at 2 19 27 PM" src="https://github.com/user-attachments/assets/bcd3b3e9-c09b-497d-b452-5f5fc2e3288a" />

### Note for reviewer
- Added unit tests that check most parameters, excluding those only available in a specific detection type. (For example, `resource_type` for policies)