### PR TITLE
fix: Use parse_bool for PANTHER_ALLOW_INSECURE_INSTANCE

### DIFF
--- a/src/mcp_panther/panther_mcp_core/client.py
+++ b/src/mcp_panther/panther_mcp_core/client.py
@@ -13,6 +13,8 @@ from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportQueryError
 
+from .utils import parse_bool
+
 PACKAGE_NAME = "mcp-panther"
 
 # Get logger
@@ -57,7 +59,7 @@ async def get_json_from_script_tag(
     """
     async with aiohttp.ClientSession() as session:
         async with session.get(
-            url, ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")
+            url, ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"))
         ) as response:
             if response.status != 200:
                 raise UnexpectedResponseStatusError(
@@ -563,7 +565,7 @@ class PantherRestClient:
             self._build_url(path),
             headers=self._headers,
             params=params,
-            ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"),
+            ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")),
         ) as response:
             await self._validate_response(response, expected_codes)
             return await response.json(), response.status
@@ -599,7 +601,7 @@ class PantherRestClient:
             headers=self._headers,
             json=json_data,
             params=params,
-            ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"),
+            ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")),
         ) as response:
             await self._validate_response(response, expected_codes)
             return await response.json(), response.status
@@ -635,7 +637,7 @@ class PantherRestClient:
             headers=self._headers,
             json=json_data,
             params=params,
-            ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"),
+            ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")),
         ) as response:
             await self._validate_response(response, expected_codes)
             return await response.json(), response.status
@@ -671,7 +673,7 @@ class PantherRestClient:
             headers=self._headers,
             json=json_data,
             params=params,
-            ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"),
+            ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")),
         ) as response:
             await self._validate_response(response, expected_codes)
             return await response.json(), response.status
@@ -704,7 +706,7 @@ class PantherRestClient:
             self._build_url(path),
             headers=self._headers,
             params=params,
-            ssl=not os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"),
+            ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE")),
         ) as response:
             await self._validate_response(response, expected_codes)
             return await response.json(), response.status

--- a/tests/panther_mcp_core/test_client.py
+++ b/tests/panther_mcp_core/test_client.py
@@ -132,6 +132,38 @@ async def test_get_instance_config_fallback():
             assert config == {"rest": "http://example.com"}
 
 
+@pytest.mark.parametrize(
+    "env_value,expected_ssl",
+    [
+        ("false", True),
+        ("False", True),
+        ("0", True),
+        ("no", True),
+        ("", True),
+        ("true", False),
+        ("1", False),
+        ("yes", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_allow_insecure_instance_boolean_parsing(env_value, expected_ssl):
+    mock_response = mock.Mock(spec=ClientResponse)
+    mock_response.status = 200
+    mock_response.text.return_value = (
+        '<script id="__PANTHER_CONFIG__">{"key": "value"}</script>'
+    )
+
+    with mock.patch.dict(os.environ, {"PANTHER_ALLOW_INSECURE_INSTANCE": env_value}):
+        with mock.patch("aiohttp.ClientSession.get") as mock_get:
+            mock_get.return_value.__aenter__.return_value = mock_response
+            await get_json_from_script_tag(
+                "http://example.com", "__PANTHER_CONFIG__"
+            )
+            mock_get.assert_called_once_with(
+                "http://example.com", ssl=expected_ssl
+            )
+
+
 @pytest.mark.asyncio
 async def test_get_panther_rest_api_base():
     """Test REST API base URL resolution."""


### PR DESCRIPTION
### Description

When PANTHER_ALLOW_INSECURE_INSTANCE is set to falsey values like 0 or False it evaluates to True which may be surprising behavior resulting in an unintentionally insecure communication with the Panther API.

### References

[#150 
](https://github.com/panther-labs/mcp-panther/issues/150)

### Checklist

- [X ] Added unit tests
- [X ] Tested end to end, including screenshots or videos

### Notes for Reviewing

1. Set following environment variables
- `export PANTHER_INSTANCE_URL="https://localhost:1234"` (any unused port)
- `export PANTHER_API_TOKEN="foobar" (any value)
- `export PANTHER_ALLOW_INSECURE_INSTANCE=false` (`0` value also works)

2. Run uvx mcp-panther

3. Observe SSL setting in stack trace, should include `ssl:default` and NOT `ssl:False`
Set environment variable