### PR TITLE
fix: add trust_env=True to aiohttp sessions for proxy/sandbox compatibility

### DIFF
--- a/src/mcp_panther/panther_mcp_core/client.py
+++ b/src/mcp_panther/panther_mcp_core/client.py
@@ -57,7 +57,7 @@ async def get_json_from_script_tag(
     Returns:
         Parsed JSON content, raw string if not valid JSON, or None if not found
     """
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(
             url, ssl=not parse_bool(os.getenv("PANTHER_ALLOW_INSECURE_INSTANCE"))
         ) as response:
@@ -271,6 +271,7 @@ async def lifespan(mcp):
             client_session_args={
                 "connector": _graphql_connector,
                 "connector_owner": False,  # We manage connector lifecycle
+                "trust_env": True,  # Respect HTTP_PROXY/HTTPS_PROXY for sandboxed environments
             },
         )
 
@@ -290,6 +291,7 @@ async def lifespan(mcp):
             _rest_session = aiohttp.ClientSession(
                 connector=_rest_connector,
                 connector_owner=False,  # We manage connector lifecycle
+                trust_env=True,  # Respect HTTP_PROXY/HTTPS_PROXY for sandboxed environments
             )
             logger.info("REST session opened - ready for concurrent requests")
 


### PR DESCRIPTION
## Summary

Add `trust_env=True` to all three `aiohttp.ClientSession` instantiations in `client.py` so that mcp-panther respects `HTTP_PROXY`/`HTTPS_PROXY` environment variables.

## Problem

When mcp-panther runs inside sandboxed or proxied environments - any proxied environment or desktop/cli app using sandboxing -  `HTTP_PROXY`/`HTTPS_PROXY` env vars need to be respected for egress traffic.

`aiohttp.ClientSession` defaults `trust_env=False`, so it ignores these proxy variables and attempts direct socket connections, which fail with:

```
PermissionError: [Errno 1] Operation not permitted
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host panther.example.com:443 ssl:default [Operation not permitted]
```

This causes mcp-panther to crash during startup (in `get_json_from_script_tag()`) before it can even register its tools, and the MCP host marks the extension as disabled.

## Fix

Three sites patched — all `aiohttp.ClientSession` instantiations:

| Location | Session | Purpose |
|---|---|---|
| `get_json_from_script_tag()` (line 60) | Config fetch session | Startup — fetches `__PANTHER_CONFIG__` from instance URL |
| `AIOHTTPTransport` `client_session_args` (line 271) | GraphQL session | All GraphQL API queries |
| `_rest_session` (line 291) | REST session | All REST API calls |

## Behavior

- **Non-proxied environments**: No change — when `HTTP_PROXY`/`HTTPS_PROXY` are not set, `trust_env=True` is a no-op.
- **Proxied/sandboxed environments**: aiohttp routes requests through the proxy as intended, allowing mcp-panther to function correctly.

Note: `requests` and `httpx` both default to `trust_env=True` / respecting proxy env vars. aiohttp's `False` default is the outlier among Python HTTP clients. Ultimately, the env var trust boundary is already established by the tool's credential model; extending it to proxy config is consistent.

## Testing

All 259 existing tests pass with no changes required.

```
======================= 259 passed, 7 skipped in 39.73s ========================
```