### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,25 @@
-# Maintainers
-* @panther-labs/mcp-team @tomasz-sq
+# Default / shared ownership
+*  @panther-labs/business-platform
+
+# Context & Data
+src/mcp_panther/panther_mcp_core/tools/data_lake.py  @panther-labs/context-data-experience
+src/mcp_panther/panther_mcp_core/tools/sources.py    @panther-labs/context-data-experience
+src/mcp_panther/panther_mcp_core/tools/schemas.py    @panther-labs/context-data-experience
+
+# Detection & threat hunting
+src/mcp_panther/panther_mcp_core/tools/detections.py        @panther-labs/detection-threat-hunting-experience
+src/mcp_panther/panther_mcp_core/tools/global_helpers.py    @panther-labs/detection-threat-hunting-experience
+src/mcp_panther/panther_mcp_core/tools/data_models.py       @panther-labs/detection-threat-hunting-experience
+src/mcp_panther/panther_mcp_core/tools/scheduled_queries.py @panther-labs/detection-threat-hunting-experience
+
+# Alert response
+src/mcp_panther/panther_mcp_core/tools/alerts.py     @panther-labs/alert-response-experience
+src/mcp_panther/panther_mcp_core/prompts/             @panther-labs/alert-response-experience
+
+# Metrics (shared: alert metrics + data ingestion metrics)
+src/mcp_panther/panther_mcp_core/tools/metrics.py    @panther-labs/alert-response-experience @panther-labs/context-data-experience
+
+# Business platform
+src/mcp_panther/panther_mcp_core/tools/users.py       @panther-labs/business-platform
+src/mcp_panther/panther_mcp_core/tools/roles.py        @panther-labs/business-platform
+src/mcp_panther/panther_mcp_core/tools/permissions.py  @panther-labs/business-platform

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ cython_debug/
 .idea/
 
 .vscode/
+
+# Claude Code
+.claude/settings.local.json


### PR DESCRIPTION
### Description

- Update CODEOWNERS with domain-specific EPD team ownership (alert-response, detection-threat-hunting, context-data, business-platform)
- Add `.claude/settings.local.json` to gitignore so shared Claude Code config (e.g. agents) can be committed while keeping local settings out of version control

### Test Plan

- [x] Verify CODEOWNERS syntax is valid (GitHub will flag errors on the PR files tab)
- [x] Confirm team slugs match the actual GitHub team names under `@panther-labs/`